### PR TITLE
fix missing eslint-config-prettier

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@typescript-eslint/eslint-plugin": "6.15.0",
     "@typescript-eslint/parser": "6.15.0",
     "eslint": "8.56.0",
+    "eslint-config-prettier": "9.1.0",
     "eslint-plugin-import": "2.29.1",
     "eslint-plugin-simple-import-sort": "10.0.0"
   },
@@ -28,7 +29,6 @@
     "@types/eslint": "8.56.0",
     "@types/eslint__eslintrc": "2.1.1",
     "bun-types": "latest",
-    "eslint-config-prettier": "9.1.0",
     "typescript": "5.3.3"
   },
   "peerDependencies": {


### PR DESCRIPTION
```console
❯ bun run eslint --print-config eslint.config.js

Oops! Something went wrong! :(

ESLint: 8.56.0

Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'eslint-config-prettier' imported from /Users/fohte/ghq/github.com/fohte/fohte.net/node_modules/@fohte/eslint-config/lib/main.js
    at new NodeError (node:internal/errors:405:5)
    at packageResolve (node:internal/modules/esm/resolve:887:9)
    at moduleResolve (node:internal/modules/esm/resolve:936:20)
    at defaultResolve (node:internal/modules/esm/resolve:1129:11)
    at nextResolve (node:internal/modules/esm/loader:163:28)
    at ESMLoader.resolve (node:internal/modules/esm/loader:835:30)
    at ESMLoader.getModuleJob (node:internal/modules/esm/loader:424:18)
    at ModuleWrap.<anonymous> (node:internal/modules/esm/module_job:77:40)
    at link (node:internal/modules/esm/module_job:76:36)
```