### PR TITLE
ci: update release-please-action to v4 configuration format

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -21,11 +21,7 @@ jobs:
         id: release
         with:
           token: ${{ steps.app-token.outputs.token }}
-          release-type: node
-          # For 0.x versions: breaking changes bump minor, features bump patch
-          # This prevents jumping to 1.0.0 until we're ready for stable release
-          bump-minor-pre-major: true
-          bump-patch-for-minor-pre-major: true
+          config-file: release-please-config.json
 
   publish:
     needs: release-please

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,0 +1,5 @@
+{
+  "release-type": "node",
+  "bump-minor-pre-major": true,
+  "bump-patch-for-minor-pre-major": true
+}


### PR DESCRIPTION
## Why

- After merging PR #60, GitHub Actions failed with invalid input parameters for release-please-action
- `bump-minor-pre-major` and `bump-patch-for-minor-pre-major` are deprecated in v4

## What

- Migrate to release-please-action v4's new configuration format
- Create `release-please-config.json` with version bumping settings
- Remove deprecated input parameters from workflow and reference config file with `config-file` parameter