### PR TITLE
ci: prevent Renovate from pinning Node.js versions in GitHub Actions

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -5,6 +5,9 @@
   ],
   packageRules: [
     {
+      // Keep Node.js version ranges in GitHub Actions (e.g., '20.x') instead of pinning to specific versions
+      // This ensures the ESLint config is tested against all patch versions within the major.minor range,
+      // improving compatibility for users with different Node.js patch versions
       matchManagers: ['github-actions'],
       matchPackageNames: ['actions/setup-node'],
       rangeStrategy: 'replace',

--- a/renovate.json5
+++ b/renovate.json5
@@ -3,4 +3,11 @@
     'github>fohte/renovate-config:base.json5',
     'github>fohte/renovate-config:node.json5',
   ],
+  packageRules: [
+    {
+      matchManagers: ['github-actions'],
+      matchPackageNames: ['actions/setup-node'],
+      rangeStrategy: 'replace',
+    },
+  ],
 }


### PR DESCRIPTION
## Why

- Renovate was pinning Node.js to specific patch versions (e.g., `20.19.2`) in GitHub Actions workflows (see #59)
- For an ESLint config package, testing against a range of Node.js versions (e.g., `20.x`) is more appropriate to ensure compatibility across different patch versions that users might have

## What

- Renovate will maintain version ranges for Node.js in GitHub Actions instead of pinning to specific versions
- Future Node.js updates will preserve the `20.x` format rather than converting to `20.19.2`

🤖 Generated with [Claude Code](https://claude.ai/code)