### PR TITLE
ci: prevent Renovate from pinning Node.js versions in GitHub Actions

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -9,7 +9,7 @@
       // This ensures the ESLint config is tested against all patch versions within the major.minor range,
       // improving compatibility for users with different Node.js patch versions
       matchManagers: ['github-actions'],
-      matchPackageNames: ['actions/setup-node'],
+      matchPackageNames: ['node'],
       rangeStrategy: 'replace',
     },
   ],


### PR DESCRIPTION
## Why

- Renovate PR #59 is pinning Node.js to specific patch versions (e.g., `20.19.2`) in GitHub Actions workflows
- PR #67 attempted to fix this but used `matchPackageNames: ['actions/setup-node']`, however Renovate detects it as `node` package in the uses-with context
- For an ESLint config package, testing against a range of Node.js versions (e.g., `20.x`) is more appropriate to ensure compatibility

## What

- Renovate will maintain version ranges for Node.js in GitHub Actions instead of pinning to specific versions
- Future Node.js updates will preserve the `20.x` format rather than converting to `20.19.2`
- Fixed the package name from `actions/setup-node` to `node` to match Renovate's detection

This is a follow-up to #67.

🤖 Generated with [Claude Code](https://claude.ai/code)