### PR TITLE
fix: use regexManagers to preserve Node.js version ranges in GitHub Actions

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -4,7 +4,13 @@
     'github>fohte/renovate-config:node.json5',
   ],
   // Override the global rangeStrategy: 'pin' from base.json5
-  // GitHub Actions の node-version は範囲指定のままにする
+  // Keep Node.js version ranges in GitHub Actions (e.g., '20.x' instead of '20.19.2')
+  //
+  // NOTE: Why we need regexManagers instead of packageRules:
+  // - packageRules cannot override settings for values inside the 'with' section of GitHub Actions
+  // - Renovate detects the actions/setup-node action itself, but with:node-version requires special handling
+  // - Official docs state "not all syntaxes are supported out of the box" for GitHub Actions with parameters
+  // - PR #59 shows "node uses-with" because Renovate uses a special detection method for these cases
   regexManagers: [
     {
       fileMatch: ['^.github/workflows/[^/]+\\.ya?ml$'],

--- a/renovate.json5
+++ b/renovate.json5
@@ -3,14 +3,19 @@
     'github>fohte/renovate-config:base.json5',
     'github>fohte/renovate-config:node.json5',
   ],
-  packageRules: [
+  // Override the global rangeStrategy: 'pin' from base.json5
+  // GitHub Actions の node-version は範囲指定のままにする
+  regexManagers: [
     {
-      // Keep Node.js version ranges in GitHub Actions (e.g., '20.x') instead of pinning to specific versions
-      // This ensures the ESLint config is tested against all patch versions within the major.minor range,
-      // improving compatibility for users with different Node.js patch versions
-      matchManagers: ['github-actions'],
-      matchPackageNames: ['node'],
-      rangeStrategy: 'replace',
+      fileMatch: ['^.github/workflows/[^/]+\\.ya?ml$'],
+      matchStrings: [
+        'uses: actions/setup-node@.+\\s+with:\\s+node-version:\\s*[\'"](?<currentValue>.+?)[\'"]',
+      ],
+      datasourceTemplate: 'node-version',
+      packageNameTemplate: 'node',
+      versioningTemplate: 'node',
+      // Don't pin - keep ranges like '20.x'
+      rangeStrategyTemplate: 'replace',
     },
   ],
 }

--- a/renovate.json5
+++ b/renovate.json5
@@ -13,9 +13,8 @@
       ],
       datasourceTemplate: 'node-version',
       packageNameTemplate: 'node',
+      // 'node' versioning automatically handles ranges like '20.x' correctly
       versioningTemplate: 'node',
-      // Don't pin - keep ranges like '20.x'
-      rangeStrategyTemplate: 'replace',
     },
   ],
 }


### PR DESCRIPTION
## Why

- Despite merging #67 and #68, Renovate is still pinning Node.js versions (e.g., `20.x` → `20.19.2`)
- The global `rangeStrategy: 'pin'` from base.json5 affects all dependencies
- Standard `packageRules` cannot override settings for values inside the 'with' section of GitHub Actions
- Renovate detects `with:node-version` as a special "uses-with" dependency that requires custom handling

## What

- Adds `regexManagers` configuration to explicitly handle `node-version` in `actions/setup-node`
- Uses `versioning: 'node'` which automatically preserves version ranges (e.g., `20.x` → `22.x`)
- Includes detailed comments explaining why this approach is necessary

🤖 Generated with [Claude Code](https://claude.ai/code)