### PR TITLE
chore: configure Renovate to use replace strategy for peerDependencies

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -14,6 +14,8 @@
       matchDepTypes: ['peerDependencies'],
       commitMessagePrefix: 'feat(peerDeps): ',
       // Replace the entire version range instead of widening with || operators
+      // - default (widen): ^6.0.0 → ^6.0.0 || ^7.0.0 → ^6.0.0 || ^7.0.0 || ^8.0.0
+      // - replace: ^6.0.0 || ^7.0.0 → ^8.0.0
       rangeStrategy: 'replace',
     },
   ],

--- a/renovate.json5
+++ b/renovate.json5
@@ -13,6 +13,7 @@
       // Use feat: prefix for peer dependency updates to trigger releases
       matchDepTypes: ['peerDependencies'],
       commitMessagePrefix: 'feat(peerDeps): ',
+      rangeStrategy: 'replace',
     },
   ],
 }

--- a/renovate.json5
+++ b/renovate.json5
@@ -13,6 +13,7 @@
       // Use feat: prefix for peer dependency updates to trigger releases
       matchDepTypes: ['peerDependencies'],
       commitMessagePrefix: 'feat(peerDeps): ',
+      // Replace the entire version range instead of widening with || operators
       rangeStrategy: 'replace',
     },
   ],


### PR DESCRIPTION
## Why

- Current Renovate PRs use OR operators (`||`) to combine multiple version ranges (e.g., `^6.0.0 || ^7.0.0 || ^8.0.0`)
- This accumulation of version ranges makes dependency management more complex than necessary
- We want cleaner version ranges that only specify the latest supported version

## What

- Renovate will now use `rangeStrategy: 'replace'` for peer dependencies
- Version ranges will be replaced entirely instead of widened with `||` operators
- Future updates will use single version ranges like `^8.0.0` instead of `^6.0.0 || ^7.0.0 || ^8.0.0`

🤖 Generated with [Claude Code](https://claude.ai/code)