### PR TITLE
ci: add semantic PR title validation workflow

### DIFF
--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -2,7 +2,7 @@ name: PR Title Check
 
 on:
   pull_request:
-    types: [opened, edited, synchronize]
+    types: [opened, edited]
 
 jobs:
   check-title:
@@ -11,3 +11,5 @@ jobs:
       pull-requests: read
     steps:
       - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Why

- PR titles directly affect versioning through release-please's conventional commit parsing
- Without validation, incorrect PR title formats could lead to unexpected version bumps or missed releases 
- Manual review of PR titles is error-prone and time-consuming

## What

- Adds GitHub Actions workflow that validates PR titles follow conventional commit format
- Uses the industry-standard `amannn/action-semantic-pull-request` action
- Runs on PR open and edit events to provide immediate feedback
- Ensures consistent commit messages when using squash-merge strategy

🤖 Generated with [Claude Code](https://claude.ai/code)