### PR TITLE
ci: allow breaking change notation (!) in PR titles

### DIFF
--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -13,8 +13,8 @@ jobs:
       - uses: amannn/action-semantic-pull-request@v5
         with:
           # Custom pattern to support breaking changes with exclamation mark
-          # Matches: type, type!, type(scope), type(scope)!, type!:, type(scope)!:
-          headerPattern: '^(\w+)!?(?:\(([\w$.\-*/ ]*)\))?!?:\s*(.*)$'
-          headerPatternCorrespondence: type, scope, subject
+          # Matches: type, type!, type(scope), type!(scope) only
+          headerPattern: '^(\w+)(!)?(?:\(([\w$.\-*/ ]*)\))?:\s*(.*)$'
+          headerPatternCorrespondence: type, _, scope, subject
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -13,7 +13,8 @@ jobs:
       - uses: amannn/action-semantic-pull-request@v5
         with:
           # Custom pattern to support breaking changes with exclamation mark
-          headerPattern: '^(\w*)(?:\(([\w$.\-*/ ]*)\))?!?: (.*)$'
+          # Matches: type, type!, type(scope), type(scope)!, type!:, type(scope)!:
+          headerPattern: '^(\w+)!?(?:\(([\w$.\-*/ ]*)\))?!?:\s*(.*)$'
           headerPatternCorrespondence: type, scope, subject
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: amannn/action-semantic-pull-request@v5
         with:
           # Custom pattern to support breaking changes with exclamation mark
-          headerPattern: '^(\w*)(\(([\w$.\-*/ ]*)\))?!?: (.*)$'
-          headerPatternCorrespondence: type, scope, _, subject
+          headerPattern: '^(\w*)(?:\(([\w$.\-*/ ]*)\))?!?: (.*)$'
+          headerPatternCorrespondence: type, scope, subject
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -11,5 +11,9 @@ jobs:
       pull-requests: read
     steps:
       - uses: amannn/action-semantic-pull-request@v5
+        with:
+          # Custom pattern to support breaking changes with exclamation mark
+          headerPattern: '^(\w*)(\(([\w$.\-*/ ]*)\))?!?: (.*)$'
+          headerPatternCorrespondence: type, scope, _, subject
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Why

- PR title validation was rejecting valid conventional commit formats with breaking change notation (e.g., `feat!:`, `fix!:`)
- The error message "No release type found in pull request title" was misleading since the format is actually valid per conventional commits specification
- This prevented proper semantic versioning for breaking changes using the standard `!` notation

## What

- PR titles with breaking change notation now pass validation
- Developers can use formats like `feat!: breaking change` or `feat!(scope): breaking change` in PR titles
- The semantic-pull-request action correctly validates these titles using a custom header pattern

## Test Results

| PR Title | Expected Behavior | Result | CI Job |
|----------|-------------------|---------|---------|
| `feat!: allow breaking change notation in PR titles` | ✅ Pass | ✅ Pass | [Job #44280748305](https://github.com/fohte/eslint-config/actions/runs/15714506140/job/44280748305) |
| `feat!(ci): allow breaking change notation in PR titles` | ✅ Pass | ✅ Pass | [Job #44280774978](https://github.com/fohte/eslint-config/actions/runs/15714514389/job/44280774978) |
| `feat(ci)!: allow breaking change notation in PR titles` | ❌ Fail (non-standard format) | ❌ Fail | [Job #44280796945](https://github.com/fohte/eslint-config/actions/runs/15714521388/job/44280796945) |

🤖 Generated with [Claude Code](https://claude.ai/code)