### PR TITLE
fix(deps): raise `@typescript-eslint/*` peer range to ^8.60.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,8 +68,8 @@
     "vitest": "4.1.6"
   },
   "peerDependencies": {
-    "@typescript-eslint/eslint-plugin": "^8.57.0",
-    "@typescript-eslint/parser": "^8.57.0",
+    "@typescript-eslint/eslint-plugin": "^8.60.0",
+    "@typescript-eslint/parser": "^8.60.0",
     "eslint": "^9.0.0 || ^10.0.0",
     "eslint-config-prettier": "^10.0.0",
     "eslint-plugin-import-x": "^4.0.0",


### PR DESCRIPTION
## Purpose

- from: https://github.com/fohte/tq/pull/90
- Stop eslint from failing every `.ts` file with a parse error after `pnpm install` in downstream repos on TypeScript 6.0
    - Error: `Parsing error: Invalid value for lib provided: es2025.iterator`
    - TS 6.0 stabilized `ESNext.Iterator`, so tsconfig resolution now returns `lib.es2025.iterator.d.ts`, but `@typescript-eslint/scope-manager@8.57.x` has no lib entry for `es2025.iterator` and `Referencer.populateGlobalsFromLib` throws
    - With the current peer range `^8.57.0`, pnpm v10+ auto-install-peers picks a version near the lower bound (8.57.1), which breaks when combined with TS 6

### Reproduction steps

1. In a downstream repo that uses `@fohte/eslint-config`, set `typescript` to 6.0.3 and `@tsconfig/node-lts` to 24.0.0, then run `pnpm install`
2. Run `eslint .`
3. Every `.ts` file fails with `Parsing error: Invalid value for lib provided: es2025.iterator`

## Approach

- Raise the lower bound of `@typescript-eslint/eslint-plugin` and `@typescript-eslint/parser` in `peerDependencies` to `^8.60.0`
    - 8.60.0 adds `scope-manager/src/lib/es2025.iterator.ts` and widens its `typescript` peer range to `>=4.8.4 <6.1.0`, which accepts TS 6.0
    - `devDependencies` is already on 8.60.0, so no change is needed there
