### PR TITLE
feat: integrate @vitest/eslint-plugin recommended rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Personal ESLint configuration package with TypeScript support.
 npm install --save-dev @fohte/eslint-config
 
 # Install peer dependencies
-npm install --save-dev eslint @typescript-eslint/eslint-plugin @typescript-eslint/parser eslint-config-prettier eslint-plugin-import-x eslint-plugin-simple-import-sort
+npm install --save-dev eslint @typescript-eslint/eslint-plugin @typescript-eslint/parser eslint-config-prettier eslint-plugin-import-x eslint-plugin-simple-import-sort @vitest/eslint-plugin
 
 # Optional: If using TypeScript
 npm install --save-dev typescript

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "@types/node": "24.12.4",
     "@typescript-eslint/eslint-plugin": "8.60.0",
     "@typescript-eslint/parser": "8.60.0",
+    "@vitest/eslint-plugin": "1.6.19",
     "concurrently": "9.2.1",
     "eslint": "10.4.0",
     "eslint-config-prettier": "10.1.8",
@@ -70,6 +71,7 @@
   "peerDependencies": {
     "@typescript-eslint/eslint-plugin": "^8.60.0",
     "@typescript-eslint/parser": "^8.60.0",
+    "@vitest/eslint-plugin": "^1.0.0",
     "eslint": "^9.0.0 || ^10.0.0",
     "eslint-config-prettier": "^10.0.0",
     "eslint-plugin-import-x": "^4.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       '@typescript-eslint/parser':
         specifier: 8.60.0
         version: 8.60.0(eslint@10.4.0(jiti@2.6.1))(typescript@6.0.3)
+      '@vitest/eslint-plugin':
+        specifier: 1.6.19
+        version: 1.6.19(@typescript-eslint/eslint-plugin@8.60.0(@typescript-eslint/parser@8.60.0(eslint@10.4.0(jiti@2.6.1))(typescript@6.0.3))(eslint@10.4.0(jiti@2.6.1))(typescript@6.0.3))(eslint@10.4.0(jiti@2.6.1))(typescript@6.0.3)(vitest@4.1.6(@types/node@24.12.4)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.4)(jiti@2.6.1)))
       concurrently:
         specifier: 9.2.1
         version: 9.2.1
@@ -551,6 +554,22 @@ packages:
     resolution: {integrity: sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==}
     cpu: [x64]
     os: [win32]
+
+  '@vitest/eslint-plugin@1.6.19':
+    resolution: {integrity: sha512-zodmXRsVKFsuHxHJILuTFaaKsrsxm0YsiOX65clk+LpCW9JrVXaf6ERXr0caDs+NEk0S62Jyk0K7XYQ7gWXheA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@typescript-eslint/eslint-plugin': '*'
+      eslint: '>=8.57.0'
+      typescript: '>=5.0.0'
+      vitest: '*'
+    peerDependenciesMeta:
+      '@typescript-eslint/eslint-plugin':
+        optional: true
+      typescript:
+        optional: true
+      vitest:
+        optional: true
 
   '@vitest/expect@4.1.6':
     resolution: {integrity: sha512-7EHDquPthALSV0jhhjgEW8FXaviMx7rSqu8W6oqCoAuOhKov814P99QDV1pxMA3QPv21YudvJngIhjrNI4opLg==}
@@ -1953,6 +1972,18 @@ snapshots:
 
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
+
+  '@vitest/eslint-plugin@1.6.19(@typescript-eslint/eslint-plugin@8.60.0(@typescript-eslint/parser@8.60.0(eslint@10.4.0(jiti@2.6.1))(typescript@6.0.3))(eslint@10.4.0(jiti@2.6.1))(typescript@6.0.3))(eslint@10.4.0(jiti@2.6.1))(typescript@6.0.3)(vitest@4.1.6(@types/node@24.12.4)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.4)(jiti@2.6.1)))':
+    dependencies:
+      '@typescript-eslint/scope-manager': 8.60.0
+      '@typescript-eslint/utils': 8.60.0(eslint@10.4.0(jiti@2.6.1))(typescript@6.0.3)
+      eslint: 10.4.0(jiti@2.6.1)
+    optionalDependencies:
+      '@typescript-eslint/eslint-plugin': 8.60.0(@typescript-eslint/parser@8.60.0(eslint@10.4.0(jiti@2.6.1))(typescript@6.0.3))(eslint@10.4.0(jiti@2.6.1))(typescript@6.0.3)
+      typescript: 6.0.3
+      vitest: 4.1.6(@types/node@24.12.4)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.4)(jiti@2.6.1))
+    transitivePeerDependencies:
+      - supports-color
 
   '@vitest/expect@4.1.6':
     dependencies:

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -30,4 +30,16 @@ describe('config', () => {
 
     expect(withoutUser).toEqual(withEmptySpread)
   })
+
+  it('includes vitest rules scoped to test files', () => {
+    const result = config()
+    const vitestEntry = result.find(
+      (c) =>
+        c.plugins !== undefined && Object.keys(c.plugins).includes('vitest'),
+    )
+
+    expect(vitestEntry).toBeDefined()
+    expect(vitestEntry?.files).toBeDefined()
+    expect(vitestEntry?.rules?.['vitest/expect-expect']).toBeDefined()
+  })
 })

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,6 +6,7 @@ import {
   typescriptConfig,
   typescriptTypeCheckedConfig,
 } from './typescript.js'
+import { vitestConfig } from './vitest.js'
 
 export interface TypeScriptOptions {
   /**
@@ -42,6 +43,8 @@ export function config(
   } else {
     configs.push(...typescriptConfig)
   }
+
+  configs.push(...vitestConfig)
 
   configs.push(...userConfigs)
 

--- a/src/vitest.ts
+++ b/src/vitest.ts
@@ -1,7 +1,7 @@
 import vitestPlugin from '@vitest/eslint-plugin'
 import type { Linter } from 'eslint'
 
-export const vitestTestFiles = [
+const vitestTestFiles = [
   '**/*.{test,spec}.{ts,tsx,js,jsx,cts,mts,cjs,mjs}',
   '**/__tests__/**/*.{ts,tsx,js,jsx,cts,mts,cjs,mjs}',
 ]

--- a/src/vitest.ts
+++ b/src/vitest.ts
@@ -1,0 +1,23 @@
+import vitestPlugin from '@vitest/eslint-plugin'
+import type { Linter } from 'eslint'
+
+export const vitestTestFiles = [
+  '**/*.{test,spec}.{ts,tsx,js,jsx,cts,mts,cjs,mjs}',
+  '**/__tests__/**/*.{ts,tsx,js,jsx,cts,mts,cjs,mjs}',
+]
+
+export const vitestConfig: Linter.Config[] = [
+  {
+    files: vitestTestFiles,
+    plugins: {
+      vitest: vitestPlugin,
+    },
+    rules: {
+      ...vitestPlugin.configs.recommended.rules,
+      'vitest/expect-expect': [
+        'error',
+        { assertFunctionNames: ['expect', 'expect*'] },
+      ],
+    },
+  },
+]


### PR DESCRIPTION
## Purpose

- Claude Code tends to overuse `toContain`, which lowers test case quality

## Approach

- Enable the `@vitest/eslint-plugin` recommended ruleset
