### PR TITLE
chore: surface runtime dep major bumps as breaking in release-please

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -11,19 +11,20 @@
       rangeStrategy: 'auto',
     },
     {
-      // Use deps!: so release-please treats runtime dep major bumps as breaking
-      matchDepTypes: ['dependencies'],
-      matchUpdateTypes: ['major'],
-      commitMessagePrefix: 'deps!: ',
-    },
-    {
-      // Use feat: prefix for peer dependency updates to trigger releases
+      // Use feat: prefix for non-major peer dependency updates to trigger
+      // releases. Major bumps are overridden to deps!: by the rule below.
       matchDepTypes: ['peerDependencies'],
       commitMessagePrefix: 'feat(peerDeps): ',
       // Replace the entire version range instead of widening with || operators
       // - default (widen): ^6.0.0 → ^6.0.0 || ^7.0.0 → ^6.0.0 || ^7.0.0 || ^8.0.0
       // - replace: ^6.0.0 || ^7.0.0 → ^8.0.0
       rangeStrategy: 'replace',
+    },
+    {
+      // Use deps!: so release-please treats peer/runtime dep major bumps as breaking
+      matchDepTypes: ['peerDependencies', 'dependencies'],
+      matchUpdateTypes: ['major'],
+      commitMessagePrefix: 'deps!: ',
     },
     {
       // Don't pin Node.js version in engines field

--- a/renovate.json5
+++ b/renovate.json5
@@ -11,6 +11,14 @@
       rangeStrategy: 'auto',
     },
     {
+      // Published as a library: a major bump of a runtime dependency (eslint
+      // plugin/parser/core) can break downstream lint configs via added/removed/
+      // renamed rules, so surface it as a breaking change to release-please.
+      matchDepTypes: ['dependencies'],
+      matchUpdateTypes: ['major'],
+      commitMessagePrefix: 'deps!: ',
+    },
+    {
       // Use feat: prefix for peer dependency updates to trigger releases
       matchDepTypes: ['peerDependencies'],
       commitMessagePrefix: 'feat(peerDeps): ',

--- a/renovate.json5
+++ b/renovate.json5
@@ -11,9 +11,7 @@
       rangeStrategy: 'auto',
     },
     {
-      // Published as a library: a major bump of a runtime dependency (eslint
-      // plugin/parser/core) can break downstream lint configs via added/removed/
-      // renamed rules, so surface it as a breaking change to release-please.
+      // Use deps!: so release-please treats runtime dep major bumps as breaking
       matchDepTypes: ['dependencies'],
       matchUpdateTypes: ['major'],
       commitMessagePrefix: 'deps!: ',


### PR DESCRIPTION
## Purpose

- Surface runtime dependency (eslint plugin/parser/core) major bumps as breaking changes to release-please so downstream lint config breakage ships under a proper version bump instead of a patch
    - The shared base switches major bumps to non-breaking ([fohte/renovate-config#371](https://github.com/fohte/renovate-config/pull/371)), so this library needs to override that

## Approach

- Notify release-please of runtime dependency major bumps as breaking changes
