### PR TITLE
feat: add eslint-plugin-eslint-comments rules

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
   },
   "devDependencies": {
     "@commitlint/cli": "21.0.2",
+    "@eslint-community/eslint-plugin-eslint-comments": "4.7.2",
     "@eslint/eslintrc": "3.3.5",
     "@fohte/eslint-config": "0.3.3",
     "@tsconfig/node-lts": "24.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@commitlint/cli':
         specifier: 21.0.2
         version: 21.0.2(@types/node@24.12.4)(conventional-commits-parser@6.4.0)(typescript@6.0.3)
+      '@eslint-community/eslint-plugin-eslint-comments':
+        specifier: 4.7.2
+        version: 4.7.2(eslint@10.4.1(jiti@2.6.1))
       '@eslint/eslintrc':
         specifier: 3.3.5
         version: 3.3.5
@@ -161,6 +164,12 @@ packages:
 
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
+
+  '@eslint-community/eslint-plugin-eslint-comments@4.7.2':
+    resolution: {integrity: sha512-LF03qURSwEWm2dz5wtdDCzNk+7Opl0X7q6I3undsaIuNsEiNvRV3BCtqu14Q/6Pzg1tBj44LcxpW2EpSLZStZw==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0
 
   '@eslint-community/eslint-utils@4.9.1':
     resolution: {integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==}
@@ -1620,6 +1629,12 @@ snapshots:
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@eslint-community/eslint-plugin-eslint-comments@4.7.2(eslint@10.4.1(jiti@2.6.1))':
+    dependencies:
+      escape-string-regexp: 4.0.0
+      eslint: 10.4.1(jiti@2.6.1)
+      ignore: 7.0.5
 
   '@eslint-community/eslint-utils@4.9.1(eslint@10.4.1(jiti@2.6.1))':
     dependencies:

--- a/src/__tests__/e2e/helpers/e2e-test-helper.ts
+++ b/src/__tests__/e2e/helpers/e2e-test-helper.ts
@@ -137,7 +137,7 @@ export function runESLint(
       stdio: 'pipe',
     })
 
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- JSON.parse returns any
     return JSON.parse(output) as ESLintOutput
   } catch (error: unknown) {
     // ESLint exits with code 1 when there are linting errors
@@ -145,11 +145,11 @@ export function runESLint(
       error instanceof Error &&
       'stdout' in error &&
       typeof (error as { stdout: unknown }).stdout === 'string'
-        ? // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+        ? // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- TS doesn't narrow `error as { stdout: unknown }` to `{ stdout: string }` from the typeof guard
           (error as { stdout: string }).stdout
         : undefined
     if (stdout !== undefined) {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- ESLint --format=json output shape is stable
       return JSON.parse(stdout) as ESLintOutput
     }
     throw error

--- a/src/__tests__/e2e/helpers/e2e-test-helper.ts
+++ b/src/__tests__/e2e/helpers/e2e-test-helper.ts
@@ -144,12 +144,11 @@ export function runESLint(
     const stdout =
       error instanceof Error &&
       'stdout' in error &&
-      typeof (error as { stdout: unknown }).stdout === 'string'
-        ? // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- TS doesn't narrow `error as { stdout: unknown }` to `{ stdout: string }` from the typeof guard
-          (error as { stdout: string }).stdout
+      typeof error.stdout === 'string'
+        ? error.stdout
         : undefined
     if (stdout !== undefined) {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- ESLint --format=json output shape is stable
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- JSON.parse returns any
       return JSON.parse(stdout) as ESLintOutput
     }
     throw error

--- a/src/__tests__/e2e/typescript-rules.e2e.test.ts
+++ b/src/__tests__/e2e/typescript-rules.e2e.test.ts
@@ -270,27 +270,5 @@ module.exports = { root: path.resolve(__dirname) }
         },
       )
     })
-
-    it('allows eslint-disable comment for no-require-imports in .cjs files', () => {
-      withTestProject(
-        {
-          typeChecked: true,
-          files: [
-            {
-              path: 'config.cjs',
-              content: `// eslint-disable-next-line @typescript-eslint/no-require-imports
-const path = require('path')
-
-module.exports = { root: path.resolve(__dirname) }
-`,
-            },
-          ],
-        },
-        (projectDir) => {
-          const output = runESLint(projectDir)
-          expectNoErrors(output)
-        },
-      )
-    })
   })
 })

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,14 +1,19 @@
+import eslintCommentsPlugin from '@eslint-community/eslint-plugin-eslint-comments'
 import type { Linter } from 'eslint'
 import eslintConfigPrettier from 'eslint-config-prettier'
 import importXPlugin from 'eslint-plugin-import-x'
 import simpleImportSortPlugin from 'eslint-plugin-simple-import-sort'
 
-// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- ESLint.Plugin.rules widens to any in strict-type-checked
 export const mainConfig: Linter.Config[] = [
   {
+    linterOptions: {
+      reportUnusedDisableDirectives: 'error',
+    },
     plugins: {
       'simple-import-sort': simpleImportSortPlugin,
       'import-x': importXPlugin,
+      '@eslint-community/eslint-comments': eslintCommentsPlugin,
     },
     rules: {
       'no-unused-vars': 'off',
@@ -17,6 +22,9 @@ export const mainConfig: Linter.Config[] = [
       'import-x/first': 'error',
       'import-x/newline-after-import': 'error',
       'import-x/no-duplicates': 'error',
+      '@eslint-community/eslint-comments/no-unlimited-disable': 'error',
+      '@eslint-community/eslint-comments/no-unused-disable': 'error',
+      '@eslint-community/eslint-comments/require-description': 'error',
     },
   },
   eslintConfigPrettier,

--- a/src/types/eslint-plugin-eslint-comments.d.ts
+++ b/src/types/eslint-plugin-eslint-comments.d.ts
@@ -1,0 +1,6 @@
+import type { ESLint } from 'eslint'
+
+declare module '@eslint-community/eslint-plugin-eslint-comments' {
+  const plugin: ESLint.Plugin
+  export default plugin
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,10 @@
         "./src/types/eslint-plugin-simple-import-sort.d.ts"
       ],
       "eslint-plugin-import-x": ["./src/types/eslint-plugin-import.d.ts"],
-      "eslint-config-prettier": ["./src/types/eslint-config-prettier.d.ts"]
+      "eslint-config-prettier": ["./src/types/eslint-config-prettier.d.ts"],
+      "@eslint-community/eslint-plugin-eslint-comments": [
+        "./src/types/eslint-plugin-eslint-comments.d.ts"
+      ]
     }
   },
   "include": ["./src/**/*"],


### PR DESCRIPTION
## Purpose

- AI coding agents like Claude Code tend to bypass lint errors by slapping `eslint-disable` comments instead of fixing the underlying issue, which silently degrades code quality over time
- Reject the following `eslint-disable` comment patterns in projects using `@fohte/eslint-config`
    - Unrestricted disables without rule IDs
    - Disables with no rationale
    - Stale disables left behind after refactors

## Approach

- Add `@eslint-community/eslint-plugin-eslint-comments` as a dependency and enable rules that flag the three patterns in Purpose as errors
- Also enable ESLint's built-in detection of unused disable directives so unused disables are still caught when consumers override the plugin rule
