### PR TITLE
fix: declare @eslint-community/eslint-plugin-eslint-comments as peer dep

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,14 @@ pnpm exec release-please release-pr --repo-url=https://github.com/fohte/eslint-c
 
 # Warnings
 
+## Adding a plugin to `mainConfig`
+
+When wiring a new ESLint plugin into `src/main.ts` (or any exported config), update all three:
+
+- `package.json` `peerDependencies`: declare the plugin so consumers install a compatible version
+- `README.md` Installation section: append the plugin to the `npm install --save-dev` peer deps command
+- `package.json` `devDependencies`: pin the version used for local development
+
 ## release-please configuration
 
 - The config uses manifest mode with an empty component for single-package repos

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Personal ESLint configuration package with TypeScript support.
 npm install --save-dev @fohte/eslint-config
 
 # Install peer dependencies
-npm install --save-dev eslint @typescript-eslint/eslint-plugin @typescript-eslint/parser eslint-config-prettier eslint-plugin-import-x eslint-plugin-simple-import-sort @vitest/eslint-plugin @eslint-community/eslint-plugin-eslint-comments
+npm install --save-dev @eslint-community/eslint-plugin-eslint-comments @typescript-eslint/eslint-plugin @typescript-eslint/parser @vitest/eslint-plugin eslint eslint-config-prettier eslint-plugin-import-x eslint-plugin-simple-import-sort
 
 # Optional: If using TypeScript
 npm install --save-dev typescript

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Personal ESLint configuration package with TypeScript support.
 npm install --save-dev @fohte/eslint-config
 
 # Install peer dependencies
-npm install --save-dev eslint @typescript-eslint/eslint-plugin @typescript-eslint/parser eslint-config-prettier eslint-plugin-import-x eslint-plugin-simple-import-sort @vitest/eslint-plugin
+npm install --save-dev eslint @typescript-eslint/eslint-plugin @typescript-eslint/parser eslint-config-prettier eslint-plugin-import-x eslint-plugin-simple-import-sort @vitest/eslint-plugin @eslint-community/eslint-plugin-eslint-comments
 
 # Optional: If using TypeScript
 npm install --save-dev typescript

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "vitest": "4.1.8"
   },
   "peerDependencies": {
+    "@eslint-community/eslint-plugin-eslint-comments": "^4.0.0",
     "@typescript-eslint/eslint-plugin": "^8.60.0",
     "@typescript-eslint/parser": "^8.60.0",
     "@vitest/eslint-plugin": "^1.0.0",


### PR DESCRIPTION
## Purpose

- from: https://github.com/fohte/eslint-config/pull/368
- Consumers installing `@fohte/eslint-config` hit a runtime error because `mainConfig` cannot resolve `@eslint-community/eslint-plugin-eslint-comments`

## Approach

- Add to `peerDependencies`
- Append to the install command in the README
- Document the files that must stay in sync when adding a plugin to `mainConfig` in `CLAUDE.md`
