### PR TITLE
ci: pin mise version to 2026.6.6 in release-please workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -38,6 +38,8 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+        with:
+          version: 2026.6.6
 
       - run: corepack enable
 


### PR DESCRIPTION
## Purpose

- from: https://github.com/fohte/generic-boilerplate/pull/428
- Align the mise version org-wide so the `publish` job runs on the same environment as the copier template

## Approach

- Apply the same pin to `release-please.yml`, which lives outside copier's managed set
