### PR TITLE
ci: add boilerplate-update workflow stub

### DIFF
--- a/.github/workflows/boilerplate-update.yml
+++ b/.github/workflows/boilerplate-update.yml
@@ -1,0 +1,10 @@
+name: Boilerplate update
+
+on:
+  workflow_dispatch:
+
+jobs:
+  noop:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "stub"


### PR DESCRIPTION
## Purpose

- Allow iterating on `boilerplate-update.yml` from a feature branch as part of the PoC that replaces Renovate's Copier manager with a dedicated workflow for generic-boilerplate updates
    - GitHub rejects `workflow_dispatch --ref <branch>` unless the workflow file already exists on the default branch, which blocks PoC iteration

## Approach

- Land a stub containing only `on: workflow_dispatch` on master; the real implementation lives on a separate branch
