### PR TITLE
ci: prevent boilerplate-update from failing on unmerged index

### DIFF
--- a/.github/workflows/boilerplate-update.yml
+++ b/.github/workflows/boilerplate-update.yml
@@ -60,6 +60,9 @@ jobs:
           set -euo pipefail
           branch="copier-update/${TARGET_VERSION}"
           echo "name=${branch}" >> "$GITHUB_OUTPUT"
+          # copier-update-action leaves unmerged entries in the index when
+          # conflicts remain; stage everything so `git checkout -B` succeeds.
+          git add -A
           git checkout -B "${branch}"
 
       - name: Commit and push changes


### PR DESCRIPTION
## Purpose

- The [boilerplate-update workflow](https://github.com/fohte/eslint-config/blob/1290929/.github/workflows/boilerplate-update.yml) fails at the `Create branch` step with `error: you need to resolve your current index first` on manual dispatch, never reaching PR creation
    - Failing run: https://github.com/fohte/eslint-config/actions/runs/28415427264

## Approach

- Stage everything with `git add -A` before `git checkout -B` so unmerged entries are recorded as resolved
