### PR TITLE
ci(boilerplate-update): force-push copier-update branch to reset against master

### DIFF
--- a/.github/workflows/boilerplate-update.yml
+++ b/.github/workflows/boilerplate-update.yml
@@ -98,10 +98,10 @@ jobs:
           GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
         run: |
           set -euo pipefail
-          # Attribute the commit to the octo-sts federated identity (the token's actual owner),
-          # not github-actions[bot]. The previous suzuki-shunsuke/commit-action created commits
-          # via the GitHub API, which auto-attributes to the token's identity; replicating that
-          # for a local git commit requires resolving the identity from the API ourselves.
+          # Resolve the commit author from the octo-sts federated token so commits are attributed
+          # to the federated identity (the token's actual owner) instead of the generic
+          # github-actions[bot]. `gh api /user` returns the App installation's bot identity,
+          # whose noreply email follows `<id>+<login>@users.noreply.github.com`.
           user_json=$(gh api /user)
           user_id=$(jq -r '.id' <<<"${user_json}")
           user_login=$(jq -r '.login' <<<"${user_json}")

--- a/.github/workflows/boilerplate-update.yml
+++ b/.github/workflows/boilerplate-update.yml
@@ -92,11 +92,23 @@ jobs:
 
       - name: Commit and push changes
         if: steps.copier-update.outputs.changed == 'true'
-        uses: suzuki-shunsuke/commit-action@06e3b49d4706498d325d29bd85adc82ecf2f5d8f # v1.0.0
-        with:
-          commit_message: ${{ steps.title.outputs.value }}
-          workflow: deny
-          github_token: ${{ steps.octo-sts.outputs.token }}
+        env:
+          BRANCH: ${{ steps.branch.outputs.name }}
+          COMMIT_MESSAGE: ${{ steps.title.outputs.value }}
+        run: |
+          set -euo pipefail
+          # Force-push so the remote branch always equals "master HEAD + 1 copier-update commit".
+          # Without this, commits on an existing copier-update/<version> branch accumulate and
+          # the PR drifts from master.
+          git -c user.name='github-actions[bot]' \
+              -c user.email='41898282+github-actions[bot]@users.noreply.github.com' \
+              commit -m "${COMMIT_MESSAGE}"
+          # Use --force (not --force-with-lease): actions/checkout does not populate
+          # refs/remotes/origin/<branch> for non-checked-out branches, so --force-with-lease
+          # would reject with "stale info" on the second run for the same target version.
+          # The concurrency group above serializes runs, so there is no concurrent-pusher race
+          # to guard against.
+          git push --force origin "${BRANCH}"
 
       - name: Create or update pull request
         if: steps.copier-update.outputs.changed == 'true'

--- a/.github/workflows/boilerplate-update.yml
+++ b/.github/workflows/boilerplate-update.yml
@@ -95,15 +95,24 @@ jobs:
         env:
           BRANCH: ${{ steps.branch.outputs.name }}
           COMMIT_MESSAGE: ${{ steps.title.outputs.value }}
+          GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
         run: |
           set -euo pipefail
+          # Attribute the commit to the octo-sts federated identity (the token's actual owner),
+          # not github-actions[bot]. The previous suzuki-shunsuke/commit-action created commits
+          # via the GitHub API, which auto-attributes to the token's identity; replicating that
+          # for a local git commit requires resolving the identity from the API ourselves.
+          user_json=$(gh api /user)
+          user_id=$(jq -r '.id' <<<"${user_json}")
+          user_login=$(jq -r '.login' <<<"${user_json}")
+          git -c "user.name=${user_login}" \
+              -c "user.email=${user_id}+${user_login}@users.noreply.github.com" \
+              commit -m "${COMMIT_MESSAGE}"
           # Force-push so the remote branch always equals "master HEAD + 1 copier-update commit".
           # Without this, commits on an existing copier-update/<version> branch accumulate and
           # the PR drifts from master.
-          git -c user.name='github-actions[bot]' \
-              -c user.email='41898282+github-actions[bot]@users.noreply.github.com' \
-              commit -m "${COMMIT_MESSAGE}"
-          # Use --force (not --force-with-lease): actions/checkout does not populate
+          #
+          # --force (not --force-with-lease): actions/checkout does not populate
           # refs/remotes/origin/<branch> for non-checked-out branches, so --force-with-lease
           # would reject with "stale info" on the second run for the same target version.
           # The concurrency group above serializes runs, so there is no concurrent-pusher race

--- a/.github/workflows/boilerplate-update.yml
+++ b/.github/workflows/boilerplate-update.yml
@@ -95,18 +95,10 @@ jobs:
         env:
           BRANCH: ${{ steps.branch.outputs.name }}
           COMMIT_MESSAGE: ${{ steps.title.outputs.value }}
-          GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
         run: |
           set -euo pipefail
-          # Resolve the commit author from the octo-sts federated token so commits are attributed
-          # to the federated identity (the token's actual owner) instead of the generic
-          # github-actions[bot]. `gh api /user` returns the App installation's bot identity,
-          # whose noreply email follows `<id>+<login>@users.noreply.github.com`.
-          user_json=$(gh api /user)
-          user_id=$(jq -r '.id' <<<"${user_json}")
-          user_login=$(jq -r '.login' <<<"${user_json}")
-          git -c "user.name=${user_login}" \
-              -c "user.email=${user_id}+${user_login}@users.noreply.github.com" \
+          git -c 'user.name=fohte-bot[bot]' \
+              -c 'user.email=139195068+fohte-bot[bot]@users.noreply.github.com' \
               commit -m "${COMMIT_MESSAGE}"
           # Force-push so the remote branch always equals "master HEAD + 1 copier-update commit".
           # Without this, commits on an existing copier-update/<version> branch accumulate and


### PR DESCRIPTION
## Purpose

- from: https://github.com/fohte/eslint-config/pull/389
- The `copier-update/<version>` branch accumulated stale commits across runs, diverging from master and producing PRs in a merge-conflicting state

## Approach

- Force-push the remote branch on every run so it always equals master HEAD plus one copier-update commit

<details>
<summary>Design decisions</summary>

#### Force-push strategy

| Decision | Design                        | Pros                                                                            | Cons                                                                                                                                                                          |
| -------- | ----------------------------- | ------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| Chosen   | `git push --force`            | The `concurrency` group already serializes the workflow, so no race to guard against | Overwrites any manually pushed commits (intended behavior for this workflow)                                                                                                  |
| Rejected | `git push --force-with-lease` | Generally recommended as a safer force-push                                     | `actions/checkout` does not populate the remote-tracking ref for non-checked-out branches, so the lease is empty and the second run is rejected with `stale info`             |

#### Commit "Verified" badge

| Decision | Design                                                  | Pros                                                                                  | Cons                                                                                                              |
| -------- | ------------------------------------------------------- | ------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
| Chosen   | Local `git commit` + `git push --force`                 | Author control and force-reset stay in a single step                                  | Commits are not signed by GitHub, so the "Verified" badge is lost                                                 |
| Rejected | Create commits via the GitHub Contents API              | The API signs commits automatically, keeping the "Verified" badge                     | Can only append on top of the existing branch tip and cannot force-reset, which is the whole point of this change |

</details>
