### PR TITLE
feat(vitest): add no-inline-object-in-expect rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,24 @@ export default config()
 // export default config({ typescript: { typeChecked: true } })
 ```
 
+### Built-in rules
+
+In addition to the upstream presets, this config ships a local plugin (`fohte`) for test files. Rules are enabled as `error` by default; override them in `eslint.config.js` if needed (e.g. `'fohte/no-inline-object-in-expect': 'off'`).
+
+- `fohte/no-inline-object-in-expect`: flags `expect(<object/array literal>).toEqual(...)` (and `toStrictEqual` / `toMatchObject`, including `await … .resolves` / `.rejects` / `.not` chains, and `as const` / `satisfies` / `!` wrapped literals). Pass the value under test directly, or split the assertion into multiple `expect()` calls.
+
+  ```ts
+  // bad
+  expect({ result, calls: spy.mock.calls.length }).toEqual({
+    result: 'ok',
+    calls: 0,
+  })
+
+  // good
+  expect(result).toBe('ok')
+  expect(spy).not.toHaveBeenCalled()
+  ```
+
 ## Development
 
 ### Setup

--- a/src/__tests__/rules/no-inline-object-in-expect.test.ts
+++ b/src/__tests__/rules/no-inline-object-in-expect.test.ts
@@ -1,0 +1,159 @@
+import tsParser from '@typescript-eslint/parser'
+import { RuleTester } from 'eslint'
+
+import { noInlineObjectInExpect } from '../../rules/no-inline-object-in-expect.js'
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    ecmaVersion: 2022,
+    sourceType: 'module',
+    parser: tsParser,
+  },
+})
+
+ruleTester.run('no-inline-object-in-expect', noInlineObjectInExpect, {
+  valid: [
+    { code: `expect(result).toEqual({ a: 1 })` },
+    { code: `expect(getList()).toEqual([1, 2])` },
+    { code: `expect(x).toBe(1)` },
+    { code: `expect({ a }).toBe(value)` },
+    { code: `expect({ a, b }).toContain(x)` },
+    { code: `await expect(getValue()).resolves.toEqual({ a: 1 })` },
+    { code: `expect(getValue()).rejects.toEqual([1, 2])` },
+    { code: `expect(getValue()).not.toEqual({ a: 1 })` },
+  ],
+  invalid: [
+    {
+      code: `expect({ a, b }).toEqual({ a: 1, b: 2 })`,
+      errors: [
+        {
+          messageId: 'inlineObject',
+          line: 1,
+          column: 8,
+          endLine: 1,
+          endColumn: 16,
+        },
+      ],
+    },
+    {
+      code: `expect([a, b]).toStrictEqual([1, 2])`,
+      errors: [
+        {
+          messageId: 'inlineArray',
+          line: 1,
+          column: 8,
+          endLine: 1,
+          endColumn: 14,
+        },
+      ],
+    },
+    {
+      code: `expect({ a }).toMatchObject({ a: 1 })`,
+      errors: [
+        {
+          messageId: 'inlineObject',
+          line: 1,
+          column: 8,
+          endLine: 1,
+          endColumn: 13,
+        },
+      ],
+    },
+    {
+      code: `await expect({ a, b }).resolves.toEqual({ a: 1, b: 2 })`,
+      errors: [
+        {
+          messageId: 'inlineObject',
+          line: 1,
+          column: 14,
+          endLine: 1,
+          endColumn: 22,
+        },
+      ],
+    },
+    {
+      code: `expect({ a, b }).rejects.toEqual({ a: 1, b: 2 })`,
+      errors: [
+        {
+          messageId: 'inlineObject',
+          line: 1,
+          column: 8,
+          endLine: 1,
+          endColumn: 16,
+        },
+      ],
+    },
+    {
+      code: `expect([a, b]).not.toStrictEqual([1, 2])`,
+      errors: [
+        {
+          messageId: 'inlineArray',
+          line: 1,
+          column: 8,
+          endLine: 1,
+          endColumn: 14,
+        },
+      ],
+    },
+    {
+      code: `expect({ a }).resolves.not.toEqual({ a: 1 })`,
+      errors: [
+        {
+          messageId: 'inlineObject',
+          line: 1,
+          column: 8,
+          endLine: 1,
+          endColumn: 13,
+        },
+      ],
+    },
+    {
+      code: `expect({ a: 1 } as const).toEqual({ a: 1 })`,
+      errors: [
+        {
+          messageId: 'inlineObject',
+          line: 1,
+          column: 8,
+          endLine: 1,
+          endColumn: 16,
+        },
+      ],
+    },
+    {
+      code: `expect([1, 2] as const).toStrictEqual([1, 2])`,
+      errors: [
+        {
+          messageId: 'inlineArray',
+          line: 1,
+          column: 8,
+          endLine: 1,
+          endColumn: 14,
+        },
+      ],
+    },
+    {
+      code: `expect({ a: 1 } satisfies { a: number }).toEqual({ a: 1 })`,
+      errors: [
+        {
+          messageId: 'inlineObject',
+          line: 1,
+          column: 8,
+          endLine: 1,
+          endColumn: 16,
+        },
+      ],
+    },
+    {
+      code: `expect({ a: 1 }!).toEqual({ a: 1 })`,
+      errors: [
+        {
+          messageId: 'inlineObject',
+          line: 1,
+          column: 8,
+          endLine: 1,
+          endColumn: 16,
+        },
+      ],
+    },
+  ],
+})

--- a/src/__tests__/rules/no-inline-object-in-expect.test.ts
+++ b/src/__tests__/rules/no-inline-object-in-expect.test.ts
@@ -21,6 +21,8 @@ ruleTester.run('no-inline-object-in-expect', noInlineObjectInExpect, {
     { code: `await expect(getValue()).resolves.toEqual({ a: 1 })` },
     { code: `expect(getValue()).rejects.toEqual([1, 2])` },
     { code: `expect(getValue()).not.toEqual({ a: 1 })` },
+    { code: `expect.soft(result).toEqual({ a: 1 })` },
+    { code: `expect.poll(() => getValue()).toEqual({ a: 1 })` },
   ],
   invalid: [
     {
@@ -152,6 +154,18 @@ ruleTester.run('no-inline-object-in-expect', noInlineObjectInExpect, {
           column: 8,
           endLine: 1,
           endColumn: 16,
+        },
+      ],
+    },
+    {
+      code: `expect.soft({ a, b }).toEqual({ a: 1, b: 2 })`,
+      errors: [
+        {
+          messageId: 'inlineObject',
+          line: 1,
+          column: 13,
+          endLine: 1,
+          endColumn: 21,
         },
       ],
     },

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,6 @@
 import type { Linter } from 'eslint'
 
+import { fohteConfig } from './fohte.js'
 import { mainConfig } from './main.js'
 import {
   typescriptBaseConfig,
@@ -45,6 +46,7 @@ export function config(
   }
 
   configs.push(...vitestConfig)
+  configs.push(...fohteConfig)
 
   configs.push(...userConfigs)
 

--- a/src/fohte.ts
+++ b/src/fohte.ts
@@ -1,0 +1,20 @@
+import type { Linter } from 'eslint'
+
+import { fohtePlugin } from './rules/index.js'
+
+const testFiles = [
+  '**/*.{test,spec}.{ts,tsx,js,jsx,cts,mts,cjs,mjs}',
+  '**/__tests__/**/*.{ts,tsx,js,jsx,cts,mts,cjs,mjs}',
+]
+
+export const fohteConfig: Linter.Config[] = [
+  {
+    files: testFiles,
+    plugins: {
+      fohte: fohtePlugin,
+    },
+    rules: {
+      'fohte/no-inline-object-in-expect': 'error',
+    },
+  },
+]

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -1,0 +1,12 @@
+import type { ESLint } from 'eslint'
+
+import { noInlineObjectInExpect } from './no-inline-object-in-expect.js'
+
+export const fohtePlugin: ESLint.Plugin = {
+  meta: {
+    name: 'fohte',
+  },
+  rules: {
+    'no-inline-object-in-expect': noInlineObjectInExpect,
+  },
+}

--- a/src/rules/no-inline-object-in-expect.ts
+++ b/src/rules/no-inline-object-in-expect.ts
@@ -48,13 +48,16 @@ export const noInlineObjectInExpect: Rule.RuleModule = {
           receiver = receiver.object
         }
 
-        if (
-          receiver.type !== 'CallExpression' ||
-          receiver.callee.type !== 'Identifier' ||
-          receiver.callee.name !== 'expect'
-        ) {
-          return
-        }
+        if (receiver.type !== 'CallExpression') return
+        const expectCallee = receiver.callee
+        const isExpect =
+          expectCallee.type === 'Identifier'
+            ? expectCallee.name === 'expect'
+            : expectCallee.type === 'MemberExpression' &&
+              !expectCallee.computed &&
+              expectCallee.object.type === 'Identifier' &&
+              expectCallee.object.name === 'expect'
+        if (!isExpect) return
 
         const firstArg = receiver.arguments[0]
         if (!firstArg) return

--- a/src/rules/no-inline-object-in-expect.ts
+++ b/src/rules/no-inline-object-in-expect.ts
@@ -1,0 +1,75 @@
+import type { Rule } from 'eslint'
+import type { Node } from 'estree'
+
+interface TsWrapperNode {
+  type: string
+  expression: Node
+}
+
+const TARGET_MATCHERS = new Set(['toEqual', 'toStrictEqual', 'toMatchObject'])
+const MODIFIER_NAMES = new Set(['resolves', 'rejects', 'not'])
+const TS_WRAPPER_TYPES = new Set([
+  'TSAsExpression',
+  'TSSatisfiesExpression',
+  'TSTypeAssertion',
+  'TSNonNullExpression',
+])
+
+export const noInlineObjectInExpect: Rule.RuleModule = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Disallow passing inline object or array literals to expect() with deep-equality matchers',
+    },
+    messages: {
+      inlineObject:
+        'Avoid passing an inline object literal to expect(). Pass the value under test directly, or split it into multiple expect() calls.',
+      inlineArray:
+        'Avoid passing an inline array literal to expect(). Pass the value under test directly, or split it into multiple expect() calls.',
+    },
+    schema: [],
+  },
+  create(context) {
+    return {
+      CallExpression(node) {
+        const callee = node.callee
+        if (callee.type !== 'MemberExpression' || callee.computed) return
+        const prop = callee.property
+        if (prop.type !== 'Identifier' || !TARGET_MATCHERS.has(prop.name))
+          return
+
+        let receiver = callee.object
+        while (
+          receiver.type === 'MemberExpression' &&
+          !receiver.computed &&
+          receiver.property.type === 'Identifier' &&
+          MODIFIER_NAMES.has(receiver.property.name)
+        ) {
+          receiver = receiver.object
+        }
+
+        if (
+          receiver.type !== 'CallExpression' ||
+          receiver.callee.type !== 'Identifier' ||
+          receiver.callee.name !== 'expect'
+        ) {
+          return
+        }
+
+        const firstArg = receiver.arguments[0]
+        if (!firstArg) return
+        let actual: Node = firstArg
+        while (TS_WRAPPER_TYPES.has(actual.type)) {
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- estree's Node union lacks TS-only wrappers (TSAsExpression etc.); their .expression field is documented in @typescript-eslint AST
+          actual = (actual as unknown as TsWrapperNode).expression
+        }
+        if (actual.type === 'ObjectExpression') {
+          context.report({ node: actual, messageId: 'inlineObject' })
+        } else if (actual.type === 'ArrayExpression') {
+          context.report({ node: actual, messageId: 'inlineArray' })
+        }
+      },
+    }
+  },
+}

--- a/src/rules/no-inline-object-in-expect.ts
+++ b/src/rules/no-inline-object-in-expect.ts
@@ -1,9 +1,8 @@
 import type { Rule } from 'eslint'
-import type { Node } from 'estree'
 
 interface TsWrapperNode {
   type: string
-  expression: Node
+  expression: { type: string }
 }
 
 const TARGET_MATCHERS = new Set(['toEqual', 'toStrictEqual', 'toMatchObject'])
@@ -59,15 +58,23 @@ export const noInlineObjectInExpect: Rule.RuleModule = {
 
         const firstArg = receiver.arguments[0]
         if (!firstArg) return
-        let actual: Node = firstArg
+        let actual: { type: string } = firstArg
         while (TS_WRAPPER_TYPES.has(actual.type)) {
           // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- estree's Node union lacks TS-only wrappers (TSAsExpression etc.); their .expression field is documented in @typescript-eslint AST
           actual = (actual as unknown as TsWrapperNode).expression
         }
-        if (actual.type === 'ObjectExpression') {
-          context.report({ node: actual, messageId: 'inlineObject' })
-        } else if (actual.type === 'ArrayExpression') {
-          context.report({ node: actual, messageId: 'inlineArray' })
+        if (
+          actual.type === 'ObjectExpression' ||
+          actual.type === 'ArrayExpression'
+        ) {
+          context.report({
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- the unwrap loop narrows from estree Node only by string type tag; ESLint's report node accepts the runtime AST node
+            node: actual as unknown as Rule.Node,
+            messageId:
+              actual.type === 'ObjectExpression'
+                ? 'inlineObject'
+                : 'inlineArray',
+          })
         }
       },
     }

--- a/src/vitest.ts
+++ b/src/vitest.ts
@@ -1,8 +1,6 @@
 import vitestPlugin from '@vitest/eslint-plugin'
 import type { Linter } from 'eslint'
 
-import { fohtePlugin } from './rules/index.js'
-
 const vitestTestFiles = [
   '**/*.{test,spec}.{ts,tsx,js,jsx,cts,mts,cjs,mjs}',
   '**/__tests__/**/*.{ts,tsx,js,jsx,cts,mts,cjs,mjs}',
@@ -13,7 +11,6 @@ export const vitestConfig: Linter.Config[] = [
     files: vitestTestFiles,
     plugins: {
       vitest: vitestPlugin,
-      fohte: fohtePlugin,
     },
     rules: {
       ...vitestPlugin.configs.recommended.rules,
@@ -21,7 +18,6 @@ export const vitestConfig: Linter.Config[] = [
         'error',
         { assertFunctionNames: ['expect', 'expect*'] },
       ],
-      'fohte/no-inline-object-in-expect': 'error',
     },
   },
 ]

--- a/src/vitest.ts
+++ b/src/vitest.ts
@@ -1,6 +1,8 @@
 import vitestPlugin from '@vitest/eslint-plugin'
 import type { Linter } from 'eslint'
 
+import { fohtePlugin } from './rules/index.js'
+
 const vitestTestFiles = [
   '**/*.{test,spec}.{ts,tsx,js,jsx,cts,mts,cjs,mjs}',
   '**/__tests__/**/*.{ts,tsx,js,jsx,cts,mts,cjs,mjs}',
@@ -11,6 +13,7 @@ export const vitestConfig: Linter.Config[] = [
     files: vitestTestFiles,
     plugins: {
       vitest: vitestPlugin,
+      fohte: fohtePlugin,
     },
     rules: {
       ...vitestPlugin.configs.recommended.rules,
@@ -18,6 +21,7 @@ export const vitestConfig: Linter.Config[] = [
         'error',
         { assertFunctionNames: ['expect', 'expect*'] },
       ],
+      'fohte/no-inline-object-in-expect': 'error',
     },
   },
 ]


### PR DESCRIPTION
## Purpose

- Claude Code keeps writing meaningless, hard-to-read tests like `expect(<object/array literal>).toEqual(...)` that bundle multiple values into a one-off object/array for a single deep-equal — flag them as lint errors automatically

## Approach

- Implement the rule locally because neither `@vitest/eslint-plugin` nor `eslint-plugin-jest` ships an equivalent
