### PR TITLE
ci(boilerplate-update): bump copier-update-action to v0.1.1

### DIFF
--- a/.github/workflows/boilerplate-update.yml
+++ b/.github/workflows/boilerplate-update.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Run copier-update-action
         id: copier-update
-        uses: fohte/copier-update-action@34a7c132e7cb49c4025dcde6b71160c0625c4796 # v0.1.0
+        uses: fohte/copier-update-action@52313ccc7ba83641a9a617252f378e54800de129 # v0.1.1
         with:
           template-repo: ${{ env.TEMPLATE_REPO }}
           target-version: ${{ github.event.inputs.target-version }}


### PR DESCRIPTION
## Purpose

- from: #396
- Runner fails with `File not found: /home/runner/work/_actions/fohte/copier-update-action/<sha>/dist/index.js` because the pinned SHA points at a main HEAD that has no `dist/` ([failed run](https://github.com/fohte/eslint-config/actions/runs/28454347647))

## Approach

- Pin to v0.1.1 ([release PR](https://redirect.github.com/fohte/copier-update-action/pull/21)), which ships `dist/` on the release commit
