### PR TITLE
fix(vitest): detect object/array literals aliased through a variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ export default config()
 
 In addition to the upstream presets, this config ships a local plugin (`fohte`) for test files. Rules are enabled as `error` by default; override them in `eslint.config.js` if needed (e.g. `'fohte/no-inline-object-in-expect': 'off'`).
 
-- `fohte/no-inline-object-in-expect`: flags `expect(<object/array literal>).toEqual(...)` (and `toStrictEqual` / `toMatchObject`, including `await … .resolves` / `.rejects` / `.not` chains, and `as const` / `satisfies` / `!` wrapped literals). Pass the value under test directly, or split the assertion into multiple `expect()` calls.
+- `fohte/no-inline-object-in-expect`: flags `expect(<object/array literal>).toEqual(...)` (and `toStrictEqual` / `toMatchObject`, including `await … .resolves` / `.rejects` / `.not` chains, and `as const` / `satisfies` / `!` wrapped literals). Also flags the same literal aliased through a variable declared right before the `expect()` call. Pass the value under test directly, or split the assertion into multiple `expect()` calls.
 
   ```ts
   // bad
@@ -41,6 +41,10 @@ In addition to the upstream presets, this config ships a local plugin (`fohte`) 
     result: 'ok',
     calls: 0,
   })
+
+  // bad: aliasing the literal through a variable doesn't escape the rule
+  const actual = { result, calls: spy.mock.calls.length }
+  expect(actual).toEqual({ result: 'ok', calls: 0 })
 
   // good
   expect(result).toBe('ok')

--- a/src/__tests__/rules/no-inline-object-in-expect.test.ts
+++ b/src/__tests__/rules/no-inline-object-in-expect.test.ts
@@ -23,6 +23,16 @@ ruleTester.run('no-inline-object-in-expect', noInlineObjectInExpect, {
     { code: `expect(getValue()).not.toEqual({ a: 1 })` },
     { code: `expect.soft(result).toEqual({ a: 1 })` },
     { code: `expect.poll(() => getValue()).toEqual({ a: 1 })` },
+    { code: `const actual = getValue()\nexpect(actual).toEqual({ a: 1 })` },
+    {
+      code: `let actual = { a: 1 }\nactual = getValue()\nexpect(actual).toEqual({ a: 1 })`,
+    },
+    {
+      code: `function f(actual) {\n  expect(actual).toEqual({ a: 1 })\n}`,
+    },
+    {
+      code: `const { actual } = getValue()\nexpect(actual).toEqual({ a: 1 })`,
+    },
   ],
   invalid: [
     {
@@ -166,6 +176,78 @@ ruleTester.run('no-inline-object-in-expect', noInlineObjectInExpect, {
           column: 13,
           endLine: 1,
           endColumn: 21,
+        },
+      ],
+    },
+    {
+      code: `const actual = { a: 1, b: 2 }\nexpect(actual).toEqual({ a: 1, b: 2 })`,
+      errors: [
+        {
+          messageId: 'inlineObjectAlias',
+          line: 2,
+          column: 8,
+          endLine: 2,
+          endColumn: 14,
+        },
+      ],
+    },
+    {
+      code: `const actual = [1, 2]\nexpect(actual).toStrictEqual([1, 2])`,
+      errors: [
+        {
+          messageId: 'inlineArrayAlias',
+          line: 2,
+          column: 8,
+          endLine: 2,
+          endColumn: 14,
+        },
+      ],
+    },
+    {
+      code: `const actual = { a: 1 } as const\nexpect(actual).toEqual({ a: 1 })`,
+      errors: [
+        {
+          messageId: 'inlineObjectAlias',
+          line: 2,
+          column: 8,
+          endLine: 2,
+          endColumn: 14,
+        },
+      ],
+    },
+    {
+      code: `let actual = { a: 1 }\nexpect(actual).toEqual({ a: 1 })`,
+      errors: [
+        {
+          messageId: 'inlineObjectAlias',
+          line: 2,
+          column: 8,
+          endLine: 2,
+          endColumn: 14,
+        },
+      ],
+    },
+    {
+      code: `const actual = { a: 1 }\nawait expect(actual).resolves.toEqual({ a: 1 })`,
+      errors: [
+        {
+          messageId: 'inlineObjectAlias',
+          line: 2,
+          column: 14,
+          endLine: 2,
+          endColumn: 20,
+        },
+      ],
+    },
+    {
+      code: `const actual = { a: 1 }\nexpect.soft(actual).toEqual({ a: 1 })`,
+      errors: [
+        {
+          messageId: 'inlineObjectAlias',
+          line: 2,
+          column: 13,
+          endLine: 2,
+          endColumn: 19,
         },
       ],
     },

--- a/src/__tests__/rules/no-inline-object-in-expect.test.ts
+++ b/src/__tests__/rules/no-inline-object-in-expect.test.ts
@@ -31,7 +31,13 @@ ruleTester.run('no-inline-object-in-expect', noInlineObjectInExpect, {
       code: `function f(actual) {\n  expect(actual).toEqual({ a: 1 })\n}`,
     },
     {
-      code: `const { actual } = getValue()\nexpect(actual).toEqual({ a: 1 })`,
+      code: `const { actual } = { a: 1 }\nexpect(actual).toEqual({ a: 1 })`,
+    },
+    {
+      code: `const actual = { a: 1 }\nactual.a = 2\nexpect(actual).toEqual({ a: 2 })`,
+    },
+    {
+      code: `const actual = [1]\nactual.push(2)\nexpect(actual).toStrictEqual([1, 2])`,
     },
   ],
   invalid: [

--- a/src/rules/no-inline-object-in-expect.ts
+++ b/src/rules/no-inline-object-in-expect.ts
@@ -23,7 +23,7 @@ function unwrapTsWrapper(node: { type: string }): { type: string } {
   return current
 }
 
-// Only follows bindings written exactly once, so the initializer is provably the value seen at the expect() call.
+// Only follows bindings referenced exactly twice (the initializing write and this expect() read), so no reassignment or mutating access (e.g. `x.a = 1`, `x.push(1)`) could have changed the value in between.
 function resolveAliasedLiteral(
   context: Rule.RuleContext,
   node: { type: string },
@@ -39,9 +39,7 @@ function resolveAliasedLiteral(
   const variable = reference?.resolved
   if (!variable) return undefined
 
-  if (variable.references.filter((ref) => ref.isWrite()).length !== 1) {
-    return undefined
-  }
+  if (variable.references.length !== 2) return undefined
 
   for (const def of variable.defs) {
     if (def.type !== 'Variable') continue
@@ -49,6 +47,26 @@ function resolveAliasedLiteral(
     return unwrapTsWrapper(def.node.init)
   }
   return undefined
+}
+
+const MESSAGE_IDS = {
+  ObjectExpression: { direct: 'inlineObject', alias: 'inlineObjectAlias' },
+  ArrayExpression: { direct: 'inlineArray', alias: 'inlineArrayAlias' },
+} as const
+
+function reportInlineLiteral(
+  context: Rule.RuleContext,
+  reportNode: { type: string },
+  literalType: keyof typeof MESSAGE_IDS,
+  isAlias: boolean,
+): void {
+  context.report({
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- ESLint's report node accepts the runtime AST node
+    node: reportNode as unknown as Rule.Node,
+    messageId: isAlias
+      ? MESSAGE_IDS[literalType].alias
+      : MESSAGE_IDS[literalType].direct,
+  })
 }
 
 export const noInlineObjectInExpect: Rule.RuleModule = {
@@ -108,14 +126,7 @@ export const noInlineObjectInExpect: Rule.RuleModule = {
           actual.type === 'ObjectExpression' ||
           actual.type === 'ArrayExpression'
         ) {
-          context.report({
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- the unwrap loop narrows from estree Node only by string type tag; ESLint's report node accepts the runtime AST node
-            node: actual as unknown as Rule.Node,
-            messageId:
-              actual.type === 'ObjectExpression'
-                ? 'inlineObject'
-                : 'inlineArray',
-          })
+          reportInlineLiteral(context, actual, actual.type, false)
           return
         }
 
@@ -124,14 +135,7 @@ export const noInlineObjectInExpect: Rule.RuleModule = {
           aliasedLiteral?.type === 'ObjectExpression' ||
           aliasedLiteral?.type === 'ArrayExpression'
         ) {
-          context.report({
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- actual is confirmed to be an Identifier at this point; ESLint's report node accepts the runtime AST node
-            node: actual as unknown as Rule.Node,
-            messageId:
-              aliasedLiteral.type === 'ObjectExpression'
-                ? 'inlineObjectAlias'
-                : 'inlineArrayAlias',
-          })
+          reportInlineLiteral(context, actual, aliasedLiteral.type, true)
         }
       },
     }

--- a/src/rules/no-inline-object-in-expect.ts
+++ b/src/rules/no-inline-object-in-expect.ts
@@ -14,6 +14,43 @@ const TS_WRAPPER_TYPES = new Set([
   'TSNonNullExpression',
 ])
 
+function unwrapTsWrapper(node: { type: string }): { type: string } {
+  let current = node
+  while (TS_WRAPPER_TYPES.has(current.type)) {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- estree's Node union lacks TS-only wrappers (TSAsExpression etc.); their .expression field is documented in @typescript-eslint AST
+    current = (current as unknown as TsWrapperNode).expression
+  }
+  return current
+}
+
+// Only follows bindings written exactly once, so the initializer is provably the value seen at the expect() call.
+function resolveAliasedLiteral(
+  context: Rule.RuleContext,
+  node: { type: string },
+): { type: string } | undefined {
+  if (node.type !== 'Identifier') return undefined
+
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- narrowed to Identifier by the check above; getScope() requires the real AST node
+  const identifierNode = node as unknown as Rule.Node
+  const scope = context.sourceCode.getScope(identifierNode)
+  const reference = scope.references.find(
+    (ref) => ref.identifier === identifierNode,
+  )
+  const variable = reference?.resolved
+  if (!variable) return undefined
+
+  if (variable.references.filter((ref) => ref.isWrite()).length !== 1) {
+    return undefined
+  }
+
+  for (const def of variable.defs) {
+    if (def.type !== 'Variable') continue
+    if (def.node.id.type !== 'Identifier' || !def.node.init) continue
+    return unwrapTsWrapper(def.node.init)
+  }
+  return undefined
+}
+
 export const noInlineObjectInExpect: Rule.RuleModule = {
   meta: {
     type: 'problem',
@@ -26,6 +63,10 @@ export const noInlineObjectInExpect: Rule.RuleModule = {
         'Avoid passing an inline object literal to expect(). Pass the value under test directly, or split it into multiple expect() calls.',
       inlineArray:
         'Avoid passing an inline array literal to expect(). Pass the value under test directly, or split it into multiple expect() calls.',
+      inlineObjectAlias:
+        'Avoid aliasing an inline object literal through a variable before passing it to expect(). Pass the value under test directly, or split it into multiple expect() calls.',
+      inlineArrayAlias:
+        'Avoid aliasing an inline array literal through a variable before passing it to expect(). Pass the value under test directly, or split it into multiple expect() calls.',
     },
     schema: [],
   },
@@ -61,11 +102,8 @@ export const noInlineObjectInExpect: Rule.RuleModule = {
 
         const firstArg = receiver.arguments[0]
         if (!firstArg) return
-        let actual: { type: string } = firstArg
-        while (TS_WRAPPER_TYPES.has(actual.type)) {
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- estree's Node union lacks TS-only wrappers (TSAsExpression etc.); their .expression field is documented in @typescript-eslint AST
-          actual = (actual as unknown as TsWrapperNode).expression
-        }
+        const actual = unwrapTsWrapper(firstArg)
+
         if (
           actual.type === 'ObjectExpression' ||
           actual.type === 'ArrayExpression'
@@ -77,6 +115,22 @@ export const noInlineObjectInExpect: Rule.RuleModule = {
               actual.type === 'ObjectExpression'
                 ? 'inlineObject'
                 : 'inlineArray',
+          })
+          return
+        }
+
+        const aliasedLiteral = resolveAliasedLiteral(context, actual)
+        if (
+          aliasedLiteral?.type === 'ObjectExpression' ||
+          aliasedLiteral?.type === 'ArrayExpression'
+        ) {
+          context.report({
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- actual is confirmed to be an Identifier at this point; ESLint's report node accepts the runtime AST node
+            node: actual as unknown as Rule.Node,
+            messageId:
+              aliasedLiteral.type === 'ObjectExpression'
+                ? 'inlineObjectAlias'
+                : 'inlineArrayAlias',
           })
         }
       },


### PR DESCRIPTION
## Purpose

- `fohte/no-inline-object-in-expect` detects an object/array literal passed directly to `expect()`, but a value aliased through a variable before being passed slips past it

## Approach

- Trace an identifier passed to `expect()` back to its declaration, and detect it the same way as a direct literal when the initializer is an object/array literal
- Exclude variables reassigned or mutated after declaration to avoid false positives

```ts
// Previously undetected
const actual = { result, calls: spy.mock.calls.length }
expect(actual).toEqual({ result: 'ok', calls: 0 })

// Now detected the same way as a direct literal, prompting a split
expect(result).toBe('ok')
expect(spy).not.toHaveBeenCalled()
```

<details>
<summary>Design decisions</summary>

#### Condition for treating a value as an alias

| Decision | Design | Pros | Cons |
| -------- | ------ | ---- | ---- |
| Chosen | Detect only when the variable has exactly two references: the initializing write and the read at `expect()` | Avoids false positives on variables reassigned or mutated (e.g. `x.a = 1`) in between | Misses aliasing when there's an extra reference in between, even a harmless one like `console.log(x)` |
| Rejected | Check only that the variable is written (reassigned) exactly once | Simpler to implement | False positives on code that mutates a property after declaration and before passing it |

</details>
