### PR TITLE
feat(opentelemetry): add a rule to catch missing context.with() calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ export default config()
 //   typescript: { typeChecked: true },
 //   errorHandling: { interopBoundaryFiles: ['src/external-sdk/**/*.ts'] },
 // })
+
+// Optionally, ban raw tracer.startSpan()/startActiveSpan() calls that skip context.with():
+// export default config({ opentelemetry: { enabled: true } })
 ```
 
 ### `errorHandling` option
@@ -50,6 +53,10 @@ When enabled, it applies two rules to all `.ts{,x}` files except test files and 
 - [`neverthrow/must-use-result`](https://www.npmjs.com/package/@ninoseki/eslint-plugin-neverthrow): bans discarding a [`neverthrow`](https://github.com/supermacro/neverthrow) `Result`/`ResultAsync` without handling it.
 
 `interopBoundaryFiles` lists the files that bridge to a throw/reject-based external API (SDK callbacks, framework handlers) or to process bootstrap that must fail fast — the only _additional_ files exempt from both rules, on top of test files.
+
+### `opentelemetry` option
+
+When enabled, `no-restricted-syntax` bans direct calls to `tracer.startSpan()`/`tracer.startActiveSpan()` on all `.ts{,x}` files. A span created via a raw `startSpan()`/`startActiveSpan()` call never becomes the parent of child spans created during its execution unless it's put into the active context via `context.with()` — forgetting that step surfaces only as a mis-parented span in a trace backend, not as a runtime error. If `context.with()` genuinely can't wrap the span (e.g. start and end happen in separate callbacks), add an `eslint-disable-next-line` comment explaining why.
 
 ### Built-in rules
 
@@ -103,6 +110,7 @@ src/
 ├── main.ts            # Base ESLint configuration
 ├── typescript.ts      # TypeScript-specific configuration
 ├── error-handling.ts  # errorHandling option (throw/try-catch ban, neverthrow enforcement)
+├── opentelemetry.ts   # opentelemetry option (startSpan/startActiveSpan ban)
 └── types/             # Type definitions for untyped packages
 ```
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,14 @@ When enabled, it applies two rules to all `.ts{,x}` files except test files and 
 
 ### `opentelemetry` option
 
-When enabled, `no-restricted-syntax` bans direct calls to `tracer.startSpan()`/`tracer.startActiveSpan()` on all `.ts{,x}` files. A span created via a raw `startSpan()`/`startActiveSpan()` call never becomes the parent of child spans created during its execution unless it's put into the active context via `context.with()` — forgetting that step surfaces only as a mis-parented span in a trace backend, not as a runtime error. If `context.with()` genuinely can't wrap the span (e.g. start and end happen in separate callbacks), add an `eslint-disable-next-line` comment explaining why.
+When enabled, `no-restricted-syntax` bans direct calls to `tracer.startSpan()`/`tracer.startActiveSpan()` on all `.ts{,x}` files, since both can silently produce a span that fails to parent child spans created during its execution:
+
+- `startSpan()` never enters the active context on its own — a child span (e.g. an HTTP call fired during this span) won't be nested under it unless the caller explicitly wraps the surrounding code in `context.with(trace.setSpan(context.active(), span), ...)`.
+- `startActiveSpan()`'s callback runs inside the active context automatically, but only for the callback's own duration — storing the span to `end()` it later (e.g. start and end split across separate callbacks) drops it from the active context before that later code runs.
+
+This surfaces only as a mis-parented span in a trace backend, not as a runtime error. If neither pattern fits, add an `eslint-disable-next-line` comment explaining why.
+
+When combined with `errorHandling`, both options configure `no-restricted-syntax` — ESLint's flat config fully replaces a rule's settings (rather than merging them) when two config objects set the same rule for the same file, so the `startSpan`/`startActiveSpan` selectors are merged into `errorHandling`'s `no-restricted-syntax` entry instead of their own config. This means the `opentelemetry` ban then shares `errorHandling`'s exemptions too: it doesn't apply to test files or the globs listed in `interopBoundaryFiles`.
 
 ### Built-in rules
 

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -112,24 +112,79 @@ describe('config', () => {
             {
               selector: "CallExpression[callee.property.name='startSpan']",
               message:
-                "Don't call tracer.startSpan()/startActiveSpan() directly — wrap the code that should run as its child in context.with(trace.setSpan(context.active(), span), ...) so nested spans (e.g. an HTTP call fired during this span) are parented correctly. If context.with() genuinely can't wrap the span (e.g. start and end happen in separate callbacks), add an eslint-disable-next-line comment explaining why.",
+                "Don't call tracer.startSpan() directly — wrap the code that should run as its child in context.with(trace.setSpan(context.active(), span), ...) so nested spans are parented correctly. startSpan() never enters the active context on its own. If context.with() genuinely can't wrap the span (e.g. start and end happen in separate callbacks), add an eslint-disable-next-line comment explaining why.",
             },
             {
               selector:
                 "CallExpression[callee.property.name='startActiveSpan']",
               message:
-                "Don't call tracer.startSpan()/startActiveSpan() directly — wrap the code that should run as its child in context.with(trace.setSpan(context.active(), span), ...) so nested spans (e.g. an HTTP call fired during this span) are parented correctly. If context.with() genuinely can't wrap the span (e.g. start and end happen in separate callbacks), add an eslint-disable-next-line comment explaining why.",
+                "Don't call tracer.startActiveSpan() and use the span outside its own callback — it's only the active context for the duration of that callback, so ending it later (e.g. start and end split across separate callbacks) breaks propagation for anything that runs after the callback returns. Keep all child-producing work inside the callback, or use tracer.startSpan() plus context.with() instead. If neither fits, add an eslint-disable-next-line comment explaining why.",
             },
           ],
         },
       })
     })
 
-    it('omits the openTelemetry config when opentelemetry is not provided', () => {
-      const withoutOption = config()
-      const withDisabled = config({ opentelemetry: { enabled: false } })
+    it('omits the opentelemetry config when opentelemetry is not provided', () => {
+      const result = config()
+      const hasNoRestrictedSyntax = result.some(
+        (c) => c.rules?.['no-restricted-syntax'] !== undefined,
+      )
 
-      expect(withoutOption).toEqual(withDisabled)
+      expect(hasNoRestrictedSyntax).toBe(false)
+    })
+
+    it('omits the opentelemetry config when opentelemetry.enabled is false', () => {
+      const result = config({ opentelemetry: { enabled: false } })
+      const hasNoRestrictedSyntax = result.some(
+        (c) => c.rules?.['no-restricted-syntax'] !== undefined,
+      )
+
+      expect(hasNoRestrictedSyntax).toBe(false)
+    })
+
+    it('merges startSpan/startActiveSpan selectors into the same no-restricted-syntax rule as errorHandling, instead of a separate config that would silently override it', () => {
+      const result = config({
+        typescript: { typeChecked: true },
+        errorHandling: { interopBoundaryFiles: [] },
+        opentelemetry: { enabled: true },
+      })
+
+      expect(result.at(-1)).toEqual({
+        files: ['**/*.ts{,x}'],
+        ignores: [
+          '**/*.{test,spec}.{ts,tsx,js,jsx,cts,mts,cjs,mjs}',
+          '**/__tests__/**/*.{ts,tsx,js,jsx,cts,mts,cjs,mjs}',
+        ],
+        plugins: { neverthrow: neverthrowPlugin },
+        rules: {
+          'no-restricted-syntax': [
+            'error',
+            {
+              selector: 'ThrowStatement',
+              message:
+                "Don't throw — return a Result via err()/errAsync(), or use ResultAsync.fromPromise() to interop with a throwing API without a local throw. Only files listed in errorHandling.interopBoundaryFiles may throw, to satisfy an external SDK's throw-based contract.",
+            },
+            {
+              selector: 'TryStatement',
+              message:
+                "Don't use try/catch — use ResultAsync.fromPromise()/.andThen()/.mapErr()/.match() to turn a failure into a Result value. Only files listed in errorHandling.interopBoundaryFiles may use try/catch, to satisfy an external SDK's throw-based contract.",
+            },
+            {
+              selector: "CallExpression[callee.property.name='startSpan']",
+              message:
+                "Don't call tracer.startSpan() directly — wrap the code that should run as its child in context.with(trace.setSpan(context.active(), span), ...) so nested spans are parented correctly. startSpan() never enters the active context on its own. If context.with() genuinely can't wrap the span (e.g. start and end happen in separate callbacks), add an eslint-disable-next-line comment explaining why.",
+            },
+            {
+              selector:
+                "CallExpression[callee.property.name='startActiveSpan']",
+              message:
+                "Don't call tracer.startActiveSpan() and use the span outside its own callback — it's only the active context for the duration of that callback, so ending it later (e.g. start and end split across separate callbacks) breaks propagation for anything that runs after the callback returns. Keep all child-producing work inside the callback, or use tracer.startSpan() plus context.with() instead. If neither fits, add an eslint-disable-next-line comment explaining why.",
+            },
+          ],
+          'neverthrow/must-use-result': 'error',
+        },
+      })
     })
   })
 })

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -99,4 +99,37 @@ describe('config', () => {
       expect(hasNeverthrowPlugin).toBe(false)
     })
   })
+
+  describe('opentelemetry', () => {
+    it('bans tracer.startSpan()/startActiveSpan() when opentelemetry.enabled is true', () => {
+      const result = config({ opentelemetry: { enabled: true } })
+
+      expect(result.at(-1)).toEqual({
+        files: ['**/*.ts{,x}'],
+        rules: {
+          'no-restricted-syntax': [
+            'error',
+            {
+              selector: "CallExpression[callee.property.name='startSpan']",
+              message:
+                "Don't call tracer.startSpan()/startActiveSpan() directly — wrap the code that should run as its child in context.with(trace.setSpan(context.active(), span), ...) so nested spans (e.g. an HTTP call fired during this span) are parented correctly. If context.with() genuinely can't wrap the span (e.g. start and end happen in separate callbacks), add an eslint-disable-next-line comment explaining why.",
+            },
+            {
+              selector:
+                "CallExpression[callee.property.name='startActiveSpan']",
+              message:
+                "Don't call tracer.startSpan()/startActiveSpan() directly — wrap the code that should run as its child in context.with(trace.setSpan(context.active(), span), ...) so nested spans (e.g. an HTTP call fired during this span) are parented correctly. If context.with() genuinely can't wrap the span (e.g. start and end happen in separate callbacks), add an eslint-disable-next-line comment explaining why.",
+            },
+          ],
+        },
+      })
+    })
+
+    it('omits the openTelemetry config when opentelemetry is not provided', () => {
+      const withoutOption = config()
+      const withDisabled = config({ opentelemetry: { enabled: false } })
+
+      expect(withoutOption).toEqual(withDisabled)
+    })
+  })
 })

--- a/src/__tests__/e2e/helpers/e2e-test-helper.ts
+++ b/src/__tests__/e2e/helpers/e2e-test-helper.ts
@@ -19,6 +19,7 @@ export interface E2ETestOptions {
   eslintArgs?: string[]
   typeChecked?: boolean
   errorHandling?: { interopBoundaryFiles: string[] }
+  opentelemetry?: { enabled?: boolean }
 }
 
 export interface ESLintMessage {
@@ -89,6 +90,11 @@ export function createTestProject(options: E2ETestOptions): string {
   if (options.errorHandling) {
     configOptionEntries.push(
       `errorHandling: ${JSON.stringify(options.errorHandling)}`,
+    )
+  }
+  if (options.opentelemetry) {
+    configOptionEntries.push(
+      `opentelemetry: ${JSON.stringify(options.opentelemetry)}`,
     )
   }
   const configOptions =

--- a/src/__tests__/e2e/opentelemetry-rules.e2e.test.ts
+++ b/src/__tests__/e2e/opentelemetry-rules.e2e.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  expectRule,
+  getMessagesForRule,
+  runESLint,
+  withTestProject,
+} from './helpers/e2e-test-helper.js'
+
+describe('OpenTelemetry Rules E2E', { timeout: 30000 }, () => {
+  it('detects tracer.startSpan() when opentelemetry.enabled is true', () => {
+    withTestProject(
+      {
+        opentelemetry: { enabled: true },
+        files: [
+          {
+            path: 'test.ts',
+            content: `declare const tracer: { startSpan: (name: string) => { end: () => void } }
+
+export function run() {
+  const span = tracer.startSpan('run')
+  span.end()
+}
+`,
+          },
+        ],
+      },
+      (projectDir) => {
+        const output = runESLint(projectDir)
+        expectRule(output, 'no-restricted-syntax')
+      },
+    )
+  })
+
+  it('detects tracer.startActiveSpan() when opentelemetry.enabled is true', () => {
+    withTestProject(
+      {
+        opentelemetry: { enabled: true },
+        files: [
+          {
+            path: 'test.ts',
+            content: `declare const tracer: {
+  startActiveSpan: <T>(name: string, fn: (span: { end: () => void }) => T) => T
+}
+
+export function run() {
+  return tracer.startActiveSpan('run', (span) => {
+    span.end()
+  })
+}
+`,
+          },
+        ],
+      },
+      (projectDir) => {
+        const output = runESLint(projectDir)
+        expectRule(output, 'no-restricted-syntax')
+      },
+    )
+  })
+
+  it('allows tracer.startSpan()/startActiveSpan() when opentelemetry is not enabled', () => {
+    withTestProject(
+      {
+        files: [
+          {
+            path: 'test.ts',
+            content: `declare const tracer: { startSpan: (name: string) => { end: () => void } }
+
+export function run() {
+  const span = tracer.startSpan('run')
+  span.end()
+}
+`,
+          },
+        ],
+      },
+      (projectDir) => {
+        const output = runESLint(projectDir)
+        const messages = getMessagesForRule(output, 'no-restricted-syntax')
+        expect(messages).toHaveLength(0)
+      },
+    )
+  })
+})

--- a/src/__tests__/e2e/opentelemetry-rules.e2e.test.ts
+++ b/src/__tests__/e2e/opentelemetry-rules.e2e.test.ts
@@ -59,7 +59,7 @@ export function run() {
     )
   })
 
-  it('allows tracer.startSpan()/startActiveSpan() when opentelemetry is not enabled', () => {
+  it('allows tracer.startSpan() when opentelemetry is not enabled', () => {
     withTestProject(
       {
         files: [
@@ -81,5 +81,100 @@ export function run() {
         expect(messages).toHaveLength(0)
       },
     )
+  })
+
+  it('allows tracer.startActiveSpan() when opentelemetry is not enabled', () => {
+    withTestProject(
+      {
+        files: [
+          {
+            path: 'test.ts',
+            content: `declare const tracer: {
+  startActiveSpan: <T>(name: string, fn: (span: { end: () => void }) => T) => T
+}
+
+export function run() {
+  return tracer.startActiveSpan('run', (span) => {
+    span.end()
+  })
+}
+`,
+          },
+        ],
+      },
+      (projectDir) => {
+        const output = runESLint(projectDir)
+        const messages = getMessagesForRule(output, 'no-restricted-syntax')
+        expect(messages).toHaveLength(0)
+      },
+    )
+  })
+
+  describe('combined with errorHandling', () => {
+    it('bans throw/try-catch and startSpan/startActiveSpan together outside test files', () => {
+      withTestProject(
+        {
+          typeChecked: true,
+          errorHandling: { interopBoundaryFiles: [] },
+          opentelemetry: { enabled: true },
+          files: [
+            {
+              path: 'test.ts',
+              content: `declare const tracer: { startSpan: (name: string) => { end: () => void } }
+
+export function run() {
+  throw new Error('boom')
+}
+
+export function run2() {
+  const span = tracer.startSpan('run2')
+  span.end()
+}
+`,
+            },
+          ],
+        },
+        (projectDir) => {
+          const output = runESLint(projectDir)
+          const messages = getMessagesForRule(output, 'no-restricted-syntax')
+          expect(messages).toHaveLength(2)
+        },
+      )
+    })
+
+    it('exempts test files from both bans, following errorHandling exemption scope', () => {
+      withTestProject(
+        {
+          typeChecked: true,
+          errorHandling: { interopBoundaryFiles: [] },
+          opentelemetry: { enabled: true },
+          files: [
+            {
+              path: 'run.test.ts',
+              content: `declare const tracer: { startSpan: (name: string) => { end: () => void } }
+
+export function run() {
+  try {
+    throw new Error('boom')
+  } catch (error) {
+    return error
+  }
+}
+
+export function run2() {
+  const span = tracer.startSpan('run2')
+  span.end()
+}
+`,
+            },
+          ],
+        },
+        (projectDir) => {
+          const output = runESLint(projectDir)
+          const messages = getMessagesForRule(output, 'no-restricted-syntax')
+          expect(messages).toHaveLength(0)
+        },
+      )
+    })
   })
 })

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,6 +6,7 @@ import {
 } from './error-handling.js'
 import { fohteConfig } from './fohte.js'
 import { mainConfig } from './main.js'
+import { openTelemetryConfig } from './opentelemetry.js'
 import {
   typescriptBaseConfig,
   typescriptConfig,
@@ -23,6 +24,15 @@ export interface TypeScriptOptions {
 
 export type { ErrorHandlingOptions }
 
+export interface OpenTelemetryOptions {
+  /**
+   * Ban raw tracer.startSpan()/startActiveSpan() calls that aren't wrapped
+   * in context.with(), since a span created this way never becomes the
+   * parent of child spans created during its execution.
+   */
+  enabled?: boolean
+}
+
 export interface ConfigOptions {
   typescript?: TypeScriptOptions
   /**
@@ -32,13 +42,14 @@ export interface ConfigOptions {
    * Result values.
    */
   errorHandling?: ErrorHandlingOptions
+  opentelemetry?: OpenTelemetryOptions
 }
 
 export function config(
   options: ConfigOptions = {},
   ...userConfigs: Linter.Config[]
 ): Linter.Config[] {
-  const { typescript, errorHandling } = options
+  const { typescript, errorHandling, opentelemetry } = options
   const typeChecked = typescript?.typeChecked ?? false
 
   if (errorHandling && !typeChecked) {
@@ -69,6 +80,10 @@ export function config(
 
   if (errorHandling) {
     configs.push(...errorHandlingConfig(errorHandling))
+  }
+
+  if (opentelemetry?.enabled === true) {
+    configs.push(...openTelemetryConfig)
   }
 
   configs.push(...userConfigs)

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,7 +6,10 @@ import {
 } from './error-handling.js'
 import { fohteConfig } from './fohte.js'
 import { mainConfig } from './main.js'
-import { openTelemetryConfig } from './opentelemetry.js'
+import {
+  openTelemetryConfig,
+  openTelemetryRestrictedSyntaxOptions,
+} from './opentelemetry.js'
 import {
   typescriptBaseConfig,
   typescriptConfig,
@@ -26,9 +29,10 @@ export type { ErrorHandlingOptions }
 
 export interface OpenTelemetryOptions {
   /**
-   * Ban raw tracer.startSpan()/startActiveSpan() calls that aren't wrapped
-   * in context.with(), since a span created this way never becomes the
-   * parent of child spans created during its execution.
+   * Ban tracer.startSpan()/startActiveSpan() calls that may not correctly
+   * parent child spans created during their execution: startSpan() never
+   * enters the active context on its own, and startActiveSpan()'s span stops
+   * being the active context once its callback returns.
    */
   enabled?: boolean
 }
@@ -78,11 +82,21 @@ export function config(
   configs.push(...vitestConfig)
   configs.push(...fohteConfig)
 
-  if (errorHandling) {
-    configs.push(...errorHandlingConfig(errorHandling))
-  }
+  const openTelemetryEnabled = opentelemetry?.enabled === true
 
-  if (opentelemetry?.enabled === true) {
+  if (errorHandling) {
+    // Both errorHandling and opentelemetry configure `no-restricted-syntax`
+    // on the same `.ts{,x}` file set. ESLint flat config fully replaces a
+    // rule's settings (not merges them) when two config objects set the same
+    // rule for the same file, so the otel selectors are merged into this
+    // same rule entry instead of being pushed as a separate config.
+    configs.push(
+      ...errorHandlingConfig(
+        errorHandling,
+        openTelemetryEnabled ? openTelemetryRestrictedSyntaxOptions : [],
+      ),
+    )
+  } else if (openTelemetryEnabled) {
     configs.push(...openTelemetryConfig)
   }
 

--- a/src/error-handling.ts
+++ b/src/error-handling.ts
@@ -3,6 +3,7 @@ import { createRequire } from 'node:module'
 import type neverthrowPluginType from '@ninoseki/eslint-plugin-neverthrow'
 import type { Linter } from 'eslint'
 
+import type { RestrictedSyntaxOption } from './opentelemetry.js'
 import { vitestTestFiles } from './vitest.js'
 
 const require = createRequire(import.meta.url)
@@ -21,6 +22,14 @@ export interface ErrorHandlingOptions {
 
 export function errorHandlingConfig(
   options: ErrorHandlingOptions,
+  // ESLint flat config fully replaces a rule's settings — rather than
+  // merging them — when two config objects set the same rule for the same
+  // file. Any other no-restricted-syntax selectors that must apply to the
+  // same file set (e.g. openTelemetryRestrictedSyntaxOptions) have to be
+  // merged into this same rule entry instead of their own config object, or
+  // whichever config is pushed last would silently drop this one's throw/
+  // try-catch ban.
+  extraRestrictedSyntax: RestrictedSyntaxOption[] = [],
 ): Linter.Config[] {
   const { interopBoundaryFiles } = options
 
@@ -56,6 +65,7 @@ export function errorHandlingConfig(
             message:
               "Don't use try/catch — use ResultAsync.fromPromise()/.andThen()/.mapErr()/.match() to turn a failure into a Result value. Only files listed in errorHandling.interopBoundaryFiles may use try/catch, to satisfy an external SDK's throw-based contract.",
           },
+          ...extraRestrictedSyntax,
         ],
         'neverthrow/must-use-result': 'error',
       },

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 export type {
   ConfigOptions,
   ErrorHandlingOptions,
+  OpenTelemetryOptions,
   TypeScriptOptions,
 } from './config.js'
 export { config } from './config.js'

--- a/src/opentelemetry.ts
+++ b/src/opentelemetry.ts
@@ -1,0 +1,28 @@
+import type { Linter } from 'eslint'
+
+// A span created via a raw startSpan()/startActiveSpan() call never becomes
+// the parent of child spans created during its execution unless it's put
+// into the active context via context.with(). Forgetting that step is an
+// easy mistake, and one that surfaces only as a mis-parented span in a trace
+// backend, not as a runtime error.
+const MESSAGE =
+  "Don't call tracer.startSpan()/startActiveSpan() directly — wrap the code that should run as its child in context.with(trace.setSpan(context.active(), span), ...) so nested spans (e.g. an HTTP call fired during this span) are parented correctly. If context.with() genuinely can't wrap the span (e.g. start and end happen in separate callbacks), add an eslint-disable-next-line comment explaining why."
+
+export const openTelemetryConfig: Linter.Config[] = [
+  {
+    files: ['**/*.ts{,x}'],
+    rules: {
+      'no-restricted-syntax': [
+        'error',
+        {
+          selector: "CallExpression[callee.property.name='startSpan']",
+          message: MESSAGE,
+        },
+        {
+          selector: "CallExpression[callee.property.name='startActiveSpan']",
+          message: MESSAGE,
+        },
+      ],
+    },
+  },
+]

--- a/src/opentelemetry.ts
+++ b/src/opentelemetry.ts
@@ -1,12 +1,33 @@
 import type { Linter } from 'eslint'
 
-// A span created via a raw startSpan()/startActiveSpan() call never becomes
-// the parent of child spans created during its execution unless it's put
-// into the active context via context.with(). Forgetting that step is an
-// easy mistake, and one that surfaces only as a mis-parented span in a trace
-// backend, not as a runtime error.
-const MESSAGE =
-  "Don't call tracer.startSpan()/startActiveSpan() directly — wrap the code that should run as its child in context.with(trace.setSpan(context.active(), span), ...) so nested spans (e.g. an HTTP call fired during this span) are parented correctly. If context.with() genuinely can't wrap the span (e.g. start and end happen in separate callbacks), add an eslint-disable-next-line comment explaining why."
+export interface RestrictedSyntaxOption {
+  selector: string
+  message: string
+}
+
+// startSpan() never enters the active context on its own, so a child span
+// created during its execution (e.g. an HTTP call fired inside it) won't be
+// parented to it unless the caller explicitly enters it via context.with().
+const START_SPAN_MESSAGE =
+  "Don't call tracer.startSpan() directly — wrap the code that should run as its child in context.with(trace.setSpan(context.active(), span), ...) so nested spans are parented correctly. startSpan() never enters the active context on its own. If context.with() genuinely can't wrap the span (e.g. start and end happen in separate callbacks), add an eslint-disable-next-line comment explaining why."
+
+// startActiveSpan()'s callback runs inside the active context automatically,
+// but only for the callback's own duration — storing the span to end() it
+// later (e.g. start and end split across separate callbacks) drops it from
+// the active context before that later code runs, so it stops parenting.
+const START_ACTIVE_SPAN_MESSAGE =
+  "Don't call tracer.startActiveSpan() and use the span outside its own callback — it's only the active context for the duration of that callback, so ending it later (e.g. start and end split across separate callbacks) breaks propagation for anything that runs after the callback returns. Keep all child-producing work inside the callback, or use tracer.startSpan() plus context.with() instead. If neither fits, add an eslint-disable-next-line comment explaining why."
+
+export const openTelemetryRestrictedSyntaxOptions: RestrictedSyntaxOption[] = [
+  {
+    selector: "CallExpression[callee.property.name='startSpan']",
+    message: START_SPAN_MESSAGE,
+  },
+  {
+    selector: "CallExpression[callee.property.name='startActiveSpan']",
+    message: START_ACTIVE_SPAN_MESSAGE,
+  },
+]
 
 export const openTelemetryConfig: Linter.Config[] = [
   {
@@ -14,14 +35,7 @@ export const openTelemetryConfig: Linter.Config[] = [
     rules: {
       'no-restricted-syntax': [
         'error',
-        {
-          selector: "CallExpression[callee.property.name='startSpan']",
-          message: MESSAGE,
-        },
-        {
-          selector: "CallExpression[callee.property.name='startActiveSpan']",
-          message: MESSAGE,
-        },
+        ...openTelemetryRestrictedSyntaxOptions,
       ],
     },
   },


### PR DESCRIPTION
## Purpose

- Catch the pitfall where a manually created OpenTelemetry span loses its parent-child relationship with child spans because `context.with()` was never called, showing up as an unrelated sibling in the trace instead

## Approach

- Add an `opentelemetry` option that bans direct calls to `tracer.startSpan()`/`tracer.startActiveSpan()` via ESLint's `no-restricted-syntax` rule

<details>
<summary>Design decisions</summary>

#### Coexistence with the `errorHandling` option

| Decision | Design | Pros | Cons |
| -------- | ------ | ---- | ---- |
| Chosen | Merge both options' selectors into the same `no-restricted-syntax` entry | Reliably keeps both rules active, per ESLint's flat config semantics | When both are enabled, the `opentelemetry` rule also follows `errorHandling`'s exemptions (test files, `interopBoundaryFiles`) |
| Rejected | Push each option as a separate config object | Simpler to implement | ESLint's flat config replaces (rather than merges) a rule's settings when two config objects set the same rule for the same file, so one rule would be silently disabled |

</details>
