### PR TITLE
feat(error-handling): replace interopBoundaryFiles with per-line disable comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,17 @@ Requires `typescript.typeChecked: true`, because `neverthrow/must-use-result` ne
 
 When enabled, it applies two rules to all `.ts{,x}` files except test files:
 
-- `no-restricted-syntax`: bans `throw` and `try`/`catch`. Return a `Result` via `err()`/`errAsync()` instead, or use `ResultAsync.fromPromise()` to interop with a throwing API without a local `throw`. If an external SDK's throw-based contract genuinely can't be wrapped that way, add an `eslint-disable-next-line` comment explaining why.
+- `no-restricted-syntax`: bans `throw` and `try`/`catch`. Return a `Result` via `err()`/`errAsync()` instead, or use `ResultAsync.fromPromise()` to interop with a throwing API without a local `throw`. If an external SDK's throw-based contract genuinely can't be wrapped that way, add an `eslint-disable-next-line` comment explaining why:
+
+  ```ts
+  // eslint-disable-next-line no-restricted-syntax -- interops with an external SDK's throw-based contract
+  try {
+    return externalSdkCall()
+  } catch (error) {
+    return err(error)
+  }
+  ```
+
 - [`neverthrow/must-use-result`](https://www.npmjs.com/package/@ninoseki/eslint-plugin-neverthrow): bans discarding a [`neverthrow`](https://github.com/supermacro/neverthrow) `Result`/`ResultAsync` without handling it.
 
 ### `opentelemetry` option

--- a/README.md
+++ b/README.md
@@ -33,10 +33,10 @@ export default config()
 // export default config({ typescript: { typeChecked: true } })
 
 // Optionally, ban throw/try-catch and enforce neverthrow Result handling
-// outside an interop boundary (requires typescript.typeChecked: true):
+// (requires typescript.typeChecked: true):
 // export default config({
 //   typescript: { typeChecked: true },
-//   errorHandling: { interopBoundaryFiles: ['src/external-sdk/**/*.ts'] },
+//   errorHandling: {},
 // })
 
 // Optionally, ban raw tracer.startSpan()/startActiveSpan() calls that skip context.with():
@@ -47,12 +47,10 @@ export default config()
 
 Requires `typescript.typeChecked: true`, because `neverthrow/must-use-result` needs type information to detect unused `Result` values.
 
-When enabled, it applies two rules to all `.ts{,x}` files except test files and the globs listed in `interopBoundaryFiles`:
+When enabled, it applies two rules to all `.ts{,x}` files except test files:
 
-- `no-restricted-syntax`: bans `throw` and `try`/`catch`. Return a `Result` via `err()`/`errAsync()` instead, or use `ResultAsync.fromPromise()` to interop with a throwing API without a local `throw`.
+- `no-restricted-syntax`: bans `throw` and `try`/`catch`. Return a `Result` via `err()`/`errAsync()` instead, or use `ResultAsync.fromPromise()` to interop with a throwing API without a local `throw`. If an external SDK's throw-based contract genuinely can't be wrapped that way, add an `eslint-disable-next-line` comment explaining why.
 - [`neverthrow/must-use-result`](https://www.npmjs.com/package/@ninoseki/eslint-plugin-neverthrow): bans discarding a [`neverthrow`](https://github.com/supermacro/neverthrow) `Result`/`ResultAsync` without handling it.
-
-`interopBoundaryFiles` lists the files that bridge to a throw/reject-based external API (SDK callbacks, framework handlers) or to process bootstrap that must fail fast — the only _additional_ files exempt from both rules, on top of test files.
 
 ### `opentelemetry` option
 
@@ -63,7 +61,7 @@ When enabled, `no-restricted-syntax` bans direct calls to `tracer.startSpan()`/`
 
 This surfaces only as a mis-parented span in a trace backend, not as a runtime error. If neither pattern fits, add an `eslint-disable-next-line` comment explaining why.
 
-When combined with `errorHandling`, both options configure `no-restricted-syntax` — ESLint's flat config fully replaces a rule's settings (rather than merging them) when two config objects set the same rule for the same file, so the `startSpan`/`startActiveSpan` selectors are merged into `errorHandling`'s `no-restricted-syntax` entry instead of their own config. This means the `opentelemetry` ban then shares `errorHandling`'s exemptions too: it doesn't apply to test files or the globs listed in `interopBoundaryFiles`.
+When combined with `errorHandling`, both options configure `no-restricted-syntax` — ESLint's flat config fully replaces a rule's settings (rather than merging them) when two config objects set the same rule for the same file, so the `startSpan`/`startActiveSpan` selectors are merged into `errorHandling`'s `no-restricted-syntax` entry instead of their own config. This means the `opentelemetry` ban then shares `errorHandling`'s exemption for test files too.
 
 ### Built-in rules
 

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -46,19 +46,17 @@ describe('config', () => {
 
   describe('errorHandling', () => {
     it('throws when errorHandling is provided without typescript.typeChecked', () => {
-      expect(() =>
-        config({ errorHandling: { interopBoundaryFiles: [] } }),
-      ).toThrow(
+      expect(() => config({ errorHandling: {} })).toThrow(
         new Error(
           'errorHandling requires typescript.typeChecked: true, because neverthrow/must-use-result needs type information to detect unused Result values.',
         ),
       )
     })
 
-    it('bans throw/try-catch and discarded neverthrow Results outside the interop boundary and test files', () => {
+    it('bans throw/try-catch and discarded neverthrow Results outside test files', () => {
       const result = config({
         typescript: { typeChecked: true },
-        errorHandling: { interopBoundaryFiles: ['src/legacy/**/*.ts'] },
+        errorHandling: {},
       })
 
       expect(result.at(-1)).toEqual({
@@ -66,7 +64,6 @@ describe('config', () => {
         ignores: [
           '**/*.{test,spec}.{ts,tsx,js,jsx,cts,mts,cjs,mjs}',
           '**/__tests__/**/*.{ts,tsx,js,jsx,cts,mts,cjs,mjs}',
-          'src/legacy/**/*.ts',
         ],
         plugins: { neverthrow: neverthrowPlugin },
         rules: {
@@ -75,12 +72,12 @@ describe('config', () => {
             {
               selector: 'ThrowStatement',
               message:
-                "Don't throw — return a Result via err()/errAsync(), or use ResultAsync.fromPromise() to interop with a throwing API without a local throw. Only files listed in errorHandling.interopBoundaryFiles may throw, to satisfy an external SDK's throw-based contract.",
+                "Don't throw — return a Result via err()/errAsync(), or use ResultAsync.fromPromise() to interop with a throwing API without a local throw. If an external SDK's throw-based contract genuinely can't be wrapped that way, add an eslint-disable-next-line comment explaining why.",
             },
             {
               selector: 'TryStatement',
               message:
-                "Don't use try/catch — use ResultAsync.fromPromise()/.andThen()/.mapErr()/.match() to turn a failure into a Result value. Only files listed in errorHandling.interopBoundaryFiles may use try/catch, to satisfy an external SDK's throw-based contract.",
+                "Don't use try/catch — use ResultAsync.fromPromise()/.andThen()/.mapErr()/.match() to turn a failure into a Result value. If an external SDK's throw-based contract genuinely can't be wrapped that way, add an eslint-disable-next-line comment explaining why.",
             },
           ],
           'neverthrow/must-use-result': 'error',
@@ -146,7 +143,7 @@ describe('config', () => {
     it('merges startSpan/startActiveSpan selectors into the same no-restricted-syntax rule as errorHandling, instead of a separate config that would silently override it', () => {
       const result = config({
         typescript: { typeChecked: true },
-        errorHandling: { interopBoundaryFiles: [] },
+        errorHandling: {},
         opentelemetry: { enabled: true },
       })
 
@@ -163,12 +160,12 @@ describe('config', () => {
             {
               selector: 'ThrowStatement',
               message:
-                "Don't throw — return a Result via err()/errAsync(), or use ResultAsync.fromPromise() to interop with a throwing API without a local throw. Only files listed in errorHandling.interopBoundaryFiles may throw, to satisfy an external SDK's throw-based contract.",
+                "Don't throw — return a Result via err()/errAsync(), or use ResultAsync.fromPromise() to interop with a throwing API without a local throw. If an external SDK's throw-based contract genuinely can't be wrapped that way, add an eslint-disable-next-line comment explaining why.",
             },
             {
               selector: 'TryStatement',
               message:
-                "Don't use try/catch — use ResultAsync.fromPromise()/.andThen()/.mapErr()/.match() to turn a failure into a Result value. Only files listed in errorHandling.interopBoundaryFiles may use try/catch, to satisfy an external SDK's throw-based contract.",
+                "Don't use try/catch — use ResultAsync.fromPromise()/.andThen()/.mapErr()/.match() to turn a failure into a Result value. If an external SDK's throw-based contract genuinely can't be wrapped that way, add an eslint-disable-next-line comment explaining why.",
             },
             {
               selector: "CallExpression[callee.property.name='startSpan']",

--- a/src/__tests__/e2e/error-handling.e2e.test.ts
+++ b/src/__tests__/e2e/error-handling.e2e.test.ts
@@ -8,11 +8,11 @@ import {
 } from './helpers/e2e-test-helper.js'
 
 describe('Error Handling Rules E2E', { timeout: 30000 }, () => {
-  it('detects throw statements outside the interop boundary', () => {
+  it('detects throw statements', () => {
     withTestProject(
       {
         typeChecked: true,
-        errorHandling: { interopBoundaryFiles: [] },
+        errorHandling: {},
         files: [
           {
             path: 'test.ts',
@@ -30,11 +30,11 @@ describe('Error Handling Rules E2E', { timeout: 30000 }, () => {
     )
   })
 
-  it('detects try/catch statements outside the interop boundary', () => {
+  it('detects try/catch statements', () => {
     withTestProject(
       {
         typeChecked: true,
-        errorHandling: { interopBoundaryFiles: [] },
+        errorHandling: {},
         files: [
           {
             path: 'test.ts',
@@ -56,17 +56,20 @@ describe('Error Handling Rules E2E', { timeout: 30000 }, () => {
     )
   })
 
-  it('allows throw/try-catch inside interop boundary files', () => {
+  it('allows throw/try-catch disabled via eslint-disable-next-line', () => {
     withTestProject(
       {
         typeChecked: true,
-        errorHandling: { interopBoundaryFiles: ['boundary.ts'] },
+        errorHandling: {},
         files: [
           {
             path: 'boundary.ts',
-            content: `export function run() {
+            content: `declare function externalSdkCall(): number
+
+export function run() {
+  // eslint-disable-next-line no-restricted-syntax -- interops with an external SDK's throw-based contract
   try {
-    throw new Error('boom')
+    return externalSdkCall()
   } catch (error) {
     return error
   }
@@ -83,11 +86,11 @@ describe('Error Handling Rules E2E', { timeout: 30000 }, () => {
     )
   })
 
-  it('allows throw/try-catch inside test files regardless of the interop boundary', () => {
+  it('allows throw/try-catch inside test files', () => {
     withTestProject(
       {
         typeChecked: true,
-        errorHandling: { interopBoundaryFiles: [] },
+        errorHandling: {},
         files: [
           {
             path: 'run.test.ts',
@@ -114,7 +117,7 @@ describe('Error Handling Rules E2E', { timeout: 30000 }, () => {
     withTestProject(
       {
         typeChecked: true,
-        errorHandling: { interopBoundaryFiles: [] },
+        errorHandling: {},
         files: [
           {
             path: 'test.ts',
@@ -138,7 +141,7 @@ export function run() {
     withTestProject(
       {
         typeChecked: true,
-        errorHandling: { interopBoundaryFiles: [] },
+        errorHandling: {},
         files: [
           {
             path: 'test.ts',

--- a/src/__tests__/e2e/error-handling.e2e.test.ts
+++ b/src/__tests__/e2e/error-handling.e2e.test.ts
@@ -56,7 +56,7 @@ describe('Error Handling Rules E2E', { timeout: 30000 }, () => {
     )
   })
 
-  it('allows throw/try-catch disabled via eslint-disable-next-line', () => {
+  it('allows try/catch disabled via eslint-disable-next-line', () => {
     withTestProject(
       {
         typeChecked: true,

--- a/src/__tests__/e2e/helpers/e2e-test-helper.ts
+++ b/src/__tests__/e2e/helpers/e2e-test-helper.ts
@@ -9,6 +9,8 @@ import {
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
+import type { ErrorHandlingOptions } from '../../../error-handling.js'
+
 export interface TestFile {
   path: string
   content: string
@@ -18,7 +20,7 @@ export interface E2ETestOptions {
   files: TestFile[]
   eslintArgs?: string[]
   typeChecked?: boolean
-  errorHandling?: object
+  errorHandling?: ErrorHandlingOptions
   opentelemetry?: { enabled?: boolean }
 }
 

--- a/src/__tests__/e2e/helpers/e2e-test-helper.ts
+++ b/src/__tests__/e2e/helpers/e2e-test-helper.ts
@@ -18,7 +18,7 @@ export interface E2ETestOptions {
   files: TestFile[]
   eslintArgs?: string[]
   typeChecked?: boolean
-  errorHandling?: { interopBoundaryFiles: string[] }
+  errorHandling?: object
   opentelemetry?: { enabled?: boolean }
 }
 

--- a/src/__tests__/e2e/opentelemetry-rules.e2e.test.ts
+++ b/src/__tests__/e2e/opentelemetry-rules.e2e.test.ts
@@ -115,7 +115,7 @@ export function run() {
       withTestProject(
         {
           typeChecked: true,
-          errorHandling: { interopBoundaryFiles: [] },
+          errorHandling: {},
           opentelemetry: { enabled: true },
           files: [
             {
@@ -146,7 +146,7 @@ export function run2() {
       withTestProject(
         {
           typeChecked: true,
-          errorHandling: { interopBoundaryFiles: [] },
+          errorHandling: {},
           opentelemetry: { enabled: true },
           files: [
             {

--- a/src/config.ts
+++ b/src/config.ts
@@ -63,6 +63,12 @@ export function config(
     )
   }
 
+  if (errorHandling && 'interopBoundaryFiles' in errorHandling) {
+    throw new Error(
+      'errorHandling.interopBoundaryFiles was removed — add an eslint-disable-next-line comment on the throw/try-catch instead.',
+    )
+  }
+
   const configs: Linter.Config[] = [...mainConfig]
 
   if (typeChecked) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -40,10 +40,11 @@ export interface OpenTelemetryOptions {
 export interface ConfigOptions {
   typescript?: TypeScriptOptions
   /**
-   * Ban throw/try-catch outside an interop boundary and forbid discarding
-   * neverthrow Results. Requires `typescript.typeChecked: true`, because
-   * neverthrow/must-use-result needs type information to detect unused
-   * Result values.
+   * Ban throw/try-catch and forbid discarding neverthrow Results. Exceptions
+   * (e.g. an external SDK's throw-based contract) go through an
+   * eslint-disable-next-line comment rather than a file-level exemption.
+   * Requires `typescript.typeChecked: true`, because neverthrow/must-use-result
+   * needs type information to detect unused Result values.
    */
   errorHandling?: ErrorHandlingOptions
   opentelemetry?: OpenTelemetryOptions
@@ -92,7 +93,6 @@ export function config(
     // same rule entry instead of being pushed as a separate config.
     configs.push(
       ...errorHandlingConfig(
-        errorHandling,
         openTelemetryEnabled ? openTelemetryRestrictedSyntaxOptions : [],
       ),
     )

--- a/src/error-handling.ts
+++ b/src/error-handling.ts
@@ -11,6 +11,9 @@ const require = createRequire(import.meta.url)
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type -- reserved for future options; presence (vs. undefined) is what toggles errorHandlingConfig on in config.ts
 export interface ErrorHandlingOptions {}
 
+const EXEMPTION_HINT =
+  "If an external SDK's throw-based contract genuinely can't be wrapped that way, add an eslint-disable-next-line comment explaining why."
+
 export function errorHandlingConfig(
   // ESLint flat config fully replaces a rule's settings — rather than
   // merging them — when two config objects set the same rule for the same
@@ -45,13 +48,11 @@ export function errorHandlingConfig(
           'error',
           {
             selector: 'ThrowStatement',
-            message:
-              "Don't throw — return a Result via err()/errAsync(), or use ResultAsync.fromPromise() to interop with a throwing API without a local throw. If an external SDK's throw-based contract genuinely can't be wrapped that way, add an eslint-disable-next-line comment explaining why.",
+            message: `Don't throw — return a Result via err()/errAsync(), or use ResultAsync.fromPromise() to interop with a throwing API without a local throw. ${EXEMPTION_HINT}`,
           },
           {
             selector: 'TryStatement',
-            message:
-              "Don't use try/catch — use ResultAsync.fromPromise()/.andThen()/.mapErr()/.match() to turn a failure into a Result value. If an external SDK's throw-based contract genuinely can't be wrapped that way, add an eslint-disable-next-line comment explaining why.",
+            message: `Don't use try/catch — use ResultAsync.fromPromise()/.andThen()/.mapErr()/.match() to turn a failure into a Result value. ${EXEMPTION_HINT}`,
           },
           ...extraRestrictedSyntax,
         ],

--- a/src/error-handling.ts
+++ b/src/error-handling.ts
@@ -8,20 +8,10 @@ import { vitestTestFiles } from './vitest.js'
 
 const require = createRequire(import.meta.url)
 
-export interface ErrorHandlingOptions {
-  /**
-   * Glob patterns for the interop boundary: files that bridge to a
-   * throw/reject-based external API (SDK callbacks, framework handlers) or
-   * to process bootstrap that must fail fast. Test files are always exempt
-   * regardless of this option; these globs add further exemptions on top of
-   * that for the throw/try-catch ban and the neverthrow Result enforcement
-   * below.
-   */
-  interopBoundaryFiles: string[]
-}
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type -- reserved for future options; presence (vs. undefined) is what toggles errorHandlingConfig on in config.ts
+export interface ErrorHandlingOptions {}
 
 export function errorHandlingConfig(
-  options: ErrorHandlingOptions,
   // ESLint flat config fully replaces a rule's settings — rather than
   // merging them — when two config objects set the same rule for the same
   // file. Any other no-restricted-syntax selectors that must apply to the
@@ -31,8 +21,6 @@ export function errorHandlingConfig(
   // try-catch ban.
   extraRestrictedSyntax: RestrictedSyntaxOption[] = [],
 ): Linter.Config[] {
-  const { interopBoundaryFiles } = options
-
   // Lazily required (not statically imported) so importing @fohte/eslint-config
   // doesn't force this optional peer dependency to resolve for consumers who
   // don't opt into errorHandling. .default unwraps the CJS-interop shape
@@ -48,7 +36,7 @@ export function errorHandlingConfig(
   return [
     {
       files: ['**/*.ts{,x}'],
-      ignores: [...vitestTestFiles, ...interopBoundaryFiles],
+      ignores: vitestTestFiles,
       plugins: {
         neverthrow: neverthrowPlugin,
       },
@@ -58,12 +46,12 @@ export function errorHandlingConfig(
           {
             selector: 'ThrowStatement',
             message:
-              "Don't throw — return a Result via err()/errAsync(), or use ResultAsync.fromPromise() to interop with a throwing API without a local throw. Only files listed in errorHandling.interopBoundaryFiles may throw, to satisfy an external SDK's throw-based contract.",
+              "Don't throw — return a Result via err()/errAsync(), or use ResultAsync.fromPromise() to interop with a throwing API without a local throw. If an external SDK's throw-based contract genuinely can't be wrapped that way, add an eslint-disable-next-line comment explaining why.",
           },
           {
             selector: 'TryStatement',
             message:
-              "Don't use try/catch — use ResultAsync.fromPromise()/.andThen()/.mapErr()/.match() to turn a failure into a Result value. Only files listed in errorHandling.interopBoundaryFiles may use try/catch, to satisfy an external SDK's throw-based contract.",
+              "Don't use try/catch — use ResultAsync.fromPromise()/.andThen()/.mapErr()/.match() to turn a failure into a Result value. If an external SDK's throw-based contract genuinely can't be wrapped that way, add an eslint-disable-next-line comment explaining why.",
           },
           ...extraRestrictedSyntax,
         ],


### PR DESCRIPTION
## Purpose

- from: https://github.com/fohte/eslint-config/pull/433, https://github.com/fohte/meshi/pull/68
- `interopBoundaryFiles` exempts an entire file (including directory-wide globs) from the throw/try-catch ban, so it also becomes an escape hatch for unrelated code added to that file later — it doesn't guard against future additions

## Approach

- Align the throw/try-catch ban in `no-restricted-syntax` with the `eslint-disable-next-line` + reason comment pattern the opentelemetry `startSpan`/`startActiveSpan` rules in the same array already use

<details>
<summary>Design decisions</summary>

#### Exception mechanism

| Decision | Design | Pros | Cons |
| -------- | ------ | ---- | ---- |
| Chosen   | `eslint-disable-next-line` + reason comment | Scopes the exception to its exact location instead of spreading to unrelated code. `reportUnusedDisableDirectives` catches disable comments that outlive their justification | Requires one comment per exception |
| Rejected | File-level ignore via `interopBoundaryFiles` | Simple to list exempt files | Everything matching the glob is unconditionally exempt, so unrelated code added later slips through too |

</details>

### Breaking changes

Removed the `errorHandling.interopBoundaryFiles` option. Passing it now throws at `config()` call time — replace the throw/try-catch in affected files with an `eslint-disable-next-line no-restricted-syntax -- reason` comment.
