### PR TITLE
chore(test): replace relative import with subpath import in e2e helper

### DIFF
--- a/src/__tests__/e2e/helpers/e2e-test-helper.ts
+++ b/src/__tests__/e2e/helpers/e2e-test-helper.ts
@@ -9,7 +9,7 @@ import {
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
-import type { ErrorHandlingOptions } from '../../../error-handling.js'
+import type { ErrorHandlingOptions } from '#error-handling.js'
 
 export interface TestFile {
   path: string


### PR DESCRIPTION
## Purpose

- `src/__tests__/e2e/helpers/e2e-test-helper.ts` still uses a relative import banned by [PR #436](https://github.com/fohte/eslint-config/pull/436), causing lint to fail

## Approach

- Replace the relative import with a `#` subpath import
